### PR TITLE
hide unnecessary fields in rails_admin and limit select objects in flow

### DIFF
--- a/app/models/concerns/after_save.rb
+++ b/app/models/concerns/after_save.rb
@@ -13,15 +13,16 @@ module AfterSave
 
   end
 
-  def data_type
-    Setup::DataType.where(model: self.class.to_s).first
+  def model_schema
+    model_name = self.class.to_s.split('::').last
+    Setup::ModelSchema.where(name: model_name).first
   end
 
   def find_events(action)
     basic_event = Setup::Event.where(name: action).first
     basic_event.throw(self) unless basic_event.nil?
 
-    Setup::Event.where(data_type: self.data_type).each {|e| e.throw(self)}
+    Setup::Event.where(model_schema: self.model_schema).each {|e| e.throw(self)}
   end
 
 end

--- a/app/models/setup/connection.rb
+++ b/app/models/setup/connection.rb
@@ -8,6 +8,13 @@ module Setup
     has_and_belongs_to_many :webhooks, :class_name => 'Setup::Webhook'
 
     validates_presence_of :name, :url
+    
+    rails_admin do 
+      field :name
+      field :url
+      field :store
+      field :token
+    end  
 
   end
 end

--- a/app/models/setup/flow.rb
+++ b/app/models/setup/flow.rb
@@ -21,6 +21,33 @@ module Setup
       }.to_json
       Cenit::Rabbit.send_to_rabbitmq(message)
     end
+    
+    rails_admin do 
+      
+      field :purpose
+      
+      field :model_schema do
+        label 'Object'
+      end
+      
+#      edit do
+        configure :model_schema do
+          associated_collection_scope do
+            #Setup::ModelSchema.after_save_callback
+            flow = bindings[:object]
+            proc { Setup::ModelSchema.where(after_save_callback: true) }
+          end
+        end
+        
+        
+        
+#      end
+
+      field :webhook
+      field :event
+      field :name
+
+    end  
 
   end
 end

--- a/app/models/setup/model_schema.rb
+++ b/app/models/setup/model_schema.rb
@@ -4,12 +4,19 @@ module Setup
     field :name, type: String
     field :after_save_callback, type: Boolean, default: false
     field :schema, type: String
+    
+    scope :after_save_callback, -> { where(after_save_callback: true) }
 
     validates_presence_of :module_name, :name, :schema
     validates_length_of :module_name, :maximum => 50
     validates_format_of :module_name, :with => /^([A-Z]+[a-z]*)+(::([A-Z]+[a-z]*)+)*$/, :multiline => true
     validates_length_of :name, :maximum => 50
     validates_format_of :module_name, :with => /^([A-Z]+[a-z]*)+$/, :multiline => true
+
+    rails_admin do 
+      field :name
+      field :after_save_callback
+    end 
 
     before_save :validates_and_load_model
 

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -21,6 +21,7 @@ RailsAdmin.config do |config|
     warden.authenticate! scope: :user
   end
   config.current_user_method { current_user} # auto-generated
+  
 
   config.actions do
     dashboard                     # mandatory

--- a/lib/tasks/sample.rake
+++ b/lib/tasks/sample.rake
@@ -84,9 +84,17 @@ namespace :sample do
         schemas.each do |file_schema|
           schema = File.read("#{base_path}/#{file_schema}")
           klass_name = file_schema.split('.json')[0].camelize
-          Setup::ModelSchema.create!(module_name: 'Hub', name: klass_name, schema: schema)
-          klass = "Hub::#{klass_name}".constantize
           
+          model_schema_attributes = {
+            module_name: 'Hub', 
+            name: klass_name, 
+            schema: schema,
+            after_save_callback: %W[ Product Order Cart Payment Return ].include?(klass_name)
+          }
+          
+          model_schema = Setup::ModelSchema.create!( model_schema_attributes )
+        
+          klass = "Hub::#{klass_name}".constantize  
           klass.delete_all
           puts "All #{klass_name.pluralize} are deleted before load sample."
         end


### PR DESCRIPTION
- Removed unnecessary fields in rails admin for the different models in Setup module, like created_at, updated_at, and more.
- Fixed AfterSave, had wrong merge and change for the version in cenit-dynamic.
- Set some dynamic models in the script sample:load with 'after_save_callback: true'.
- Limit in the form add for Flow the options for select an object (model schema), with the condition that should have after_save_callback: true.  
