### PR TITLE
Improve setup models

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,25 +1,19 @@
 "!https://codeclimate.com/github/openjaf/cenit/badges/gpa.svg!":https://codeclimate.com/github/openjaf/cenit
 
-h1. Demo Integrator for commerce solution.
+h1. Features.
 
 Rails 4.0.x with Mongoid.
 
 * MongoDB is used as a datastore with the "Mongoid":http://mongoid.org/  gem for quick development without schemas or migrations.
+* Dinamic load of Json Schemas
 * rails_admin, for build admin panel.
-* RabbitMQ for internal message.
+* RabbitMQ for internal pipeline messages.
+* Authentication (via Devise)
+* multi-tenantcy with shared-schema database
 
 h2. What Is Implemented -- and What Is Not
 
-This is a demonstration application that allows you integrate commerce solution inspire in Spree Hub (Wombat). You can configure the endpoint and see all the data through the data viewer.
-
-For the moment:
-* Only connect Spree Store endpoints.
-* Only is ready that Product objects flow throught the hub.
-
-Next Steps:
-* Add Order object flow.
-* Add OpenERP like EndPoint
-
+This is a demonstration application that allows you integrate commerce solutions inspire in Wombat. You can configure the endpoint and see all the data through the data viewer.
 
 h2. How to Use
 

--- a/app/controllers/cenit/webhook_controller.rb
+++ b/app/controllers/cenit/webhook_controller.rb
@@ -17,11 +17,9 @@
       protected
       def authorize
         
-        id = request.headers['X-Hub-Store']
+        key = request.headers['X-Hub-Store']
         token = request.headers['X-Hub-Access-Token']
-        puts "*********** id #{id} token #{token}"
-        
-        @endpoint = Setup::Connection.where(endpoint_id: id, endpoint_token: token).first
+        @endpoint = Setup::Connection.unscoped.find_by(key: key, token: token)
         unless @endpoint
           response_handler = Handler.new(@message)
           responder = response_handler.response('Unauthorized!', 401)

--- a/app/models/concerns/after_save.rb
+++ b/app/models/concerns/after_save.rb
@@ -19,10 +19,10 @@ module AfterSave
   end
 
   def find_events(action)
-    basic_event = Setup::Event.where(name: action).first
+    basic_event = Setup::Event.find_by(name: action)
     basic_event.throw(self) unless basic_event.nil?
 
-    Setup::Event.where(model_schema: self.model_schema).each {|e| e.throw(self)}
+    Setup::Event.where(model: self.model_schema).each {|e| e.throw(self)}
   end
 
 end

--- a/app/models/setup/connection.rb
+++ b/app/models/setup/connection.rb
@@ -2,8 +2,8 @@ module Setup
   class Connection < Base
     field :name, type: String
     field :url, type: String
-    field :endpoint_id, type: String
-    field :endpoint_token, type: String
+    field :key, type: String
+    field :token, type: String
 
     has_and_belongs_to_many :webhooks, :class_name => 'Setup::Webhook'
 
@@ -12,8 +12,8 @@ module Setup
     rails_admin do 
       field :name
       field :url
-      field :endpoint_id
-      field :endpoint_token
+      field :key
+      field :token
     end  
 
   end

--- a/app/models/setup/event.rb
+++ b/app/models/setup/event.rb
@@ -4,7 +4,7 @@ module Setup
 
     field :name, type: String
 
-    belongs_to :model_schema, class_name: 'Setup::ModelSchema'
+    belongs_to :model, class_name: 'Setup::ModelSchema'
 
     field :attr, type: String
     field :rule, type: String
@@ -12,24 +12,53 @@ module Setup
     field :value, type: String
 
     validates_presence_of :name
+    
+    rails_admin do
+      
+      field :name
+      field :model
+      field :rule
+      field :condition
+      field :value
+      
+      configure :model do
+        associated_collection_scope do
+          #Setup::ModelSchema.after_save_callback
+          Webhook = bindings[:object]
+          proc { Setup::ModelSchema.where(after_save_callback: true) }
+        end
+      end
+      
+    end
 
+    # The default events 'created' and 'updated' have attr nil.
+    # for this reason when applay is call without attr its return true
+    #
+    # Examples:
+    #  2) Generate and event if the product haven't price 
+    #  !product_1.price.present? <==> attr: price, rule: 'no longer present'
+    #
+    #  1) Generate and event if the order have status 'complete'
+    #  order_1.status == 'complete'?  <==> attr: status, rule: 'has changed to a value'; condition: '==' ; value: 'complete'
+    #
     # TODO: eval object value before and now
-    def apply(object=nil)
-      return true unless self.attr.present?
-
-      result = case self.rule
+    
+    def apply( object )
+      return true if attr.nil?
+      
+      result = case rule
       when 'now present'
-        !object.send(self.attr).nil?
+        object.send(attr).present?
       when 'no longer present'
-        object.send(self.attr).nil?
+        !object.send(attr).present?
       when 'has changed to a value'
-        eval [object.send(attr), self.condition, self.value].join(' ')
+        eval [object.send(attr), condition, value].join(' ')
       end
       
       return result
     end
 
-    def throw(object=nil)
+    def throw( object = nil )
       Setup::Flow.where(event: self).each {|f| f.process(object)} if apply(object)
     end
 

--- a/app/models/setup/flow.rb
+++ b/app/models/setup/flow.rb
@@ -4,16 +4,29 @@ module Setup
 
     field :name, type: String
     field :purpose, type: String
+    field :active, type: Boolean
 
-    belongs_to :model_schema, class_name: 'Setup::ModelSchema'
     belongs_to :connection, class_name: 'Setup::Connection'
     belongs_to :webhook, class_name: 'Setup::Webhook'
     belongs_to :event, class_name: 'Setup::Event'
 
-    validates_presence_of :name, :purpose, :model_schema, :connection, :webhook, :event
+    validates_presence_of :name, :purpose, :connection, :webhook, :event
+    
+    validate do
+      webhook.model == event.model
+    end  
+    
+    rails_admin do 
+      field :purpose
+      field :connection
+      field :webhook
+      field :event
+      field :name
+      field :active
+    end  
 
     def process(object, notification_id=nil)
-      return if self.model_schema != object.model_schema
+      return if webhook.model != object.model_schema
       message = {
         :flow_id => self.id,
         :object_id => object.id,
@@ -21,33 +34,6 @@ module Setup
       }.to_json
       Cenit::Rabbit.send_to_rabbitmq(message)
     end
-    
-    rails_admin do 
-      
-      field :purpose
-      
-      field :model_schema do
-        label 'Object'
-      end
-      
-#      edit do
-        configure :model_schema do
-          associated_collection_scope do
-            #Setup::ModelSchema.after_save_callback
-            flow = bindings[:object]
-            proc { Setup::ModelSchema.where(after_save_callback: true) }
-          end
-        end
-        
-        
-        
-#      end
-
-      field :webhook
-      field :event
-      field :name
-
-    end  
 
   end
 end

--- a/app/models/setup/model_schema.rb
+++ b/app/models/setup/model_schema.rb
@@ -4,6 +4,7 @@ module Setup
     field :name, type: String
     field :after_save_callback, type: Boolean, default: false
     field :schema, type: String
+    field :active, type: Boolean
     
     scope :after_save_callback, -> { where(after_save_callback: true) }
 
@@ -14,13 +15,22 @@ module Setup
     validates_format_of :module_name, :with => /^([A-Z]+[a-z]*)+$/, :multiline => true
 
     rails_admin do 
-      field :name
-      field :after_save_callback
+      label "Model" 
+
+      list do 
+        fields :module_name, :name, :after_save_callback, :active
+      end
+      edit do 
+        fields :module_name, :name, :after_save_callback, :active, :schema
+      end
+      show do 
+        fields :module_name, :name, :after_save_callback, :active, :schema
+      end
     end 
 
     before_save :validates_and_load_model
 
-    def model
+    def instantiate
       [self.module_name, self.name].join('::').constantize
     end
 

--- a/app/models/setup/webhook.rb
+++ b/app/models/setup/webhook.rb
@@ -4,11 +4,26 @@ module Setup
 
     field :name, type: String
     field :path, type: String
-    field :purpose, type: String
 
-    belongs_to :model_schema, class_name: 'Setup::ModelSchema'
+    belongs_to :model, class_name: 'Setup::ModelSchema'
 
-    validates_presence_of :name, :path, :purpose
+    validates_presence_of :name, :path
+  
+    rails_admin do
+      
+      field :name
+      field :path
+      field :model
+
+      configure :model do
+        associated_collection_scope do
+          #Setup::ModelSchema.after_save_callback
+          Webhook = bindings[:object]
+          proc { Setup::ModelSchema.where(after_save_callback: true) }
+        end
+      end
+      
+    end
 
   end
 end

--- a/lib/tasks/sample.rake
+++ b/lib/tasks/sample.rake
@@ -10,19 +10,22 @@ namespace :sample do
       User.delete_all
       puts 'All User Deleted.'
       
-      Setup::Webhook.delete_all
+      Setup::Webhook.unscoped.delete_all
       puts 'All Webhook Deleted.'
-      
-      Setup::Flow.delete_all
-      puts 'All Webhook Deleted.'
-    
-      Setup::Connection.delete_all
+  
+      Setup::Connection.unscoped.delete_all
       puts 'All Connection Deleted.'
-      
-      Setup::ModelSchema.delete_all
+    
+      Setup::ModelSchema.unscoped.delete_all
       puts 'All ModelSchema Deleted.'
-
       
+      Setup::Event.unscoped.delete_all
+      puts 'All ModelSchema Deleted.'
+      
+      Setup::Flow.unscoped.delete_all
+      puts 'All ModelSchema Deleted.'
+      
+
       ############  CONFIG TENANT ###############
       
       Account.create! [ { name: "Grocer A"}, { name: "Grocer B"} ]
@@ -35,7 +38,13 @@ namespace :sample do
         		email: "user_#{index + 1}1@mail.com",
         		password: '12345678', 
         		password_confirmation: '12345678',
+            account: account 
         	})
+          
+        user1.account = account
+        user1.save(validate: false)
+        
+        account.owner = user1
           
         user2 = User.create!({
         		email: "user_#{index + 1}2@mail.com",
@@ -43,51 +52,12 @@ namespace :sample do
         		password_confirmation: '12345678',
         	})  
           
-        user1.account = account.id
-        user2.account = account.id
+        user2.account = account
         
-        user1.save(validate: false)
         user2.save(validate: false)
         
-        
-        
-        ############  CONFIG SETUP ###############
-        webhook_attributes = [
-          { 
-            name: 'Add Product', 
-            path: 'add_product',
-            purpose: 'sent'
-          },
-          { 
-            name: 'Update Product', 
-            path: 'update_product',
-            purpose: 'sent'
-          }
-        ]
+        ############  LOAD MODELS ###############
 
-        webhooks = Setup::Webhook.create!(webhook_attributes)
-        
-        connection_attributes = [
-          { 
-            name: 'Store I', 
-            url: 'http://localhost:3001/wombat', 
-            endpoint_store: '3001', 
-            endpoint_token: 'tresmiluno', 
-            webhooks: webhooks 
-          },
-          { 
-            name: 'Store II', 
-            url: 'http://localhost:3002/wombat', 
-            endpoint_id:'3002', 
-            endpoint_token: 'tresmildos',
-            webhooks: webhooks
-          },
-        ]
-        
-        Setup::Connection.create!(connection_attributes)
-        
-        
-        
         base_path = File.join(Rails.root, 'lib', 'jsons') 
         schemas = Dir.entries(base_path).select {|f| !File.directory? f} 
         
@@ -99,15 +69,101 @@ namespace :sample do
             module_name: 'Hub', 
             name: klass_name, 
             schema: schema,
+            active: true,
             after_save_callback: %W[ Product Order Cart Payment Return ].include?(klass_name)
           }
           
           model_schema = Setup::ModelSchema.create!( model_schema_attributes )
-        
-          klass = "Hub::#{klass_name}".constantize  
+          
+
+          
+          # Create default event 'created' and 'updated'
+          # TODO: move this code for ModelSchema class
+          
+          if model_schema.after_save_callback.present?
+            Setup::Event.create!(name: 'created', model: model_schema) 
+            Setup::Event.create!(name: 'updated', model: model_schema)
+          end
+         
+          klass = model_schema.instantiate
           klass.delete_all
           puts "All #{klass_name.pluralize} are deleted before load sample."
         end
+        
+
+        ############  CONFIG SETUP ###############
+        
+        webhook_attributes = [
+          { 
+            name: 'Add Product', 
+            path: 'add_product',
+            model: Setup::ModelSchema.find_by(name: 'Product')
+          },
+          { 
+            name: 'Update Product', 
+            path: 'update_product',
+            model: Setup::ModelSchema.find_by(name: 'Product')
+          }
+        ]
+
+        webhooks = Setup::Webhook.create!(webhook_attributes)
+        
+        connection_attributes = [
+          { 
+            name: 'Store I', 
+            url: 'http://localhost:3001/wombat', 
+            key: '3001', 
+            token: 'tresmiluno',
+          },
+          { 
+            name: 'Store II', 
+            url: 'http://localhost:3002/wombat', 
+            key:'3002', 
+            token: 'tresmildos'
+          },
+        ]
+        
+        Setup::Connection.create!(connection_attributes)
+        
+        flow_attributes = [
+          { 
+            name: 'Add Product to Store I', 
+            purpose: 'send',
+            event: Setup::Event.find_by(name: 'created', model: Setup::ModelSchema.find_by(name: 'Product')),
+            connection: Setup::Connection.find_by(name: 'Store I'),
+            webhook: Setup::Webhook.find_by(name: 'Add Product'), 
+            active: true,
+          },
+          { 
+            name: 'Update Product to Store I', 
+            purpose: 'send',
+            event: Setup::Event.find_by(name: 'created', model: Setup::ModelSchema.find_by(name: 'Product')),
+            connection: Setup::Connection.find_by(name: 'Store I'),
+            webhook: Setup::Webhook.find_by(name: 'Update Product'), 
+            active: true,
+          },
+          { 
+            name: 'Add Product to Store II', 
+            purpose: 'send',
+            event: Setup::Event.find_by(name: 'created',model: Setup::ModelSchema.find_by(name: 'Product')),
+            connection: Setup::Connection.find_by(name: 'Store II'),
+            webhook: Setup::Webhook.find_by(name: 'Add Product'), 
+            active: true,
+          },
+          { 
+            name: 'Update Product to Store II', 
+            purpose: 'send',
+            event: Setup::Event.find_by(name: 'created', model: Setup::ModelSchema.find_by(name: 'Product') ),
+            connection: Setup::Connection.find_by(name: 'Store II'),
+            webhook: Setup::Webhook.find_by(name: 'Update Product'), 
+            active: true,
+          }
+        ]
+
+        Setup::Flow.create!(flow_attributes)
+        
+        
+        ############  SAMPLE DATA ###############
         
         all_taxons = [
           ["Categories","Bags"],


### PR DESCRIPTION
- Renamed store field in connection by key, all the endpoint not necessary are store.
- Removed 'model_schema' from flow, is redundant, webhook have an object and event too.
- Removed webhook relation from connection, is redundant a Flow have a connecction and webhook.
- Added 'active' field to Flow. This permit enable or disable a Flow.
- Added 'active' field to Model Schema. This permit have a lots of models load like a library of Models and only active some of that, the variable Module allow group package of model. In the future will be possible have for example a module for store, for ERP, for CRM, etc.
- Renamed model_shema field in event and webhook by model.
- Removed 'propose' variable from webhook, is redundant because webhook have a propose variable too.
- Unscoped for find the connection with credential, because the endpoint don't have access to current account, it's enough with the endpoint use key and token for authorization. 
- Removed 'self' variable used unnecessary in some models in Setup module.
- Rename method 'model' in ModelSchema by 'instantiate' for avoid collition with new field name in other classes.
- Create in sample data the default events “created” and ‘updated’ related with each model schema.
- Add Flow to sample data.
- Tiny improve in Readme, general features
