### PR TITLE
[UPD] Cenit XMLRPC

### DIFF
--- a/lib/cenit/xmlrpc.rb
+++ b/lib/cenit/xmlrpc.rb
@@ -22,15 +22,15 @@ module Cenit
 
     def parse_method_response(xml)
       parsing_xml = Encoder.hash_decode(Hash.from_xml(xml))
-      raise "No valid method response!" unless parsing_xml['methodName'].nil?
+      fail 'No valid method response!' if parsing_xml['methodName']
       parsing_xml = parsing_xml['methodResponse']
-      if parsing_xml['fault'] != nil
+      if parsing_xml['fault']
         # is a fault structure
         [false, parsing_xml['fault']]
       else
         # is a normal return value
-        raise "Missing return value!" if parsing_xml['params'].length == 0
-        raise "Too many return values. Only one allowed!" if parsing_xml['params'].length > 1
+        fail 'Missing return value!' if parsing_xml['params'].length == 0
+        fail 'Too many return values. Only one allowed!' if parsing_xml['params'].length > 1
         [true, parsing_xml['params']['param']]
       end
     end

--- a/lib/cenit/xmlrpc.rb
+++ b/lib/cenit/xmlrpc.rb
@@ -8,11 +8,11 @@ module Cenit
 
     def method_missing(symbol, *args)
       body_request = {
-        "methodCall" => {
-          "methodName" => symbol
+        :methodCall => {
+          :methodName => symbol
         }
       }
-      body_request['methodCall']['params'] = args.collect { |p| { param: Encoder.hash_encode(p) } } unless args.empty?
+      body_request[:methodCall][:params] = args.collect { |p| { param: Encoder.hash_encode(p) } } unless args.empty?
       Encoder.encode(body_request)
     end
 
@@ -20,7 +20,7 @@ module Cenit
       method_missing(method, *args)
     end
 
-    def parse(xml)
+    def parse_method_response(xml)
       parsing_xml = Encoder.hash_decode(Hash.from_xml(xml))
       raise "No valid method response!" unless parsing_xml['methodName'].nil?
       parsing_xml = parsing_xml['methodResponse']
@@ -33,6 +33,10 @@ module Cenit
         raise "Too many return values. Only one allowed!" if parsing_xml['params'].length > 1
         [true, parsing_xml['params']['param']]
       end
+    end
+
+    def parse(xml)
+      Encoder.hash_decode(Hash.from_xml(xml))
     end
 
     module Encoder

--- a/lib/cenit/xmlrpc.rb
+++ b/lib/cenit/xmlrpc.rb
@@ -7,12 +7,13 @@ module Cenit
     end
 
     def method_missing(symbol, *args)
-      Encoder.encode(
-        methodCall: {
-          methodName: symbol,
-          params: args.collect { |p| { param: Encoder.hash_encode(p) } }
+      body_request = {
+        "methodCall" => {
+          "methodName" => symbol
         }
-      )
+      }
+      body_request['methodCall']['params'] = args.collect { |p| { param: Encoder.hash_encode(p) } } unless args.empty?
+      Encoder.encode(body_request)
     end
 
     def method_call(method, *args)
@@ -20,7 +21,18 @@ module Cenit
     end
 
     def parse(xml)
-      Encoder.hash_decode(Hash.from_xml(xml))
+      parsing_xml = Encoder.hash_decode(Hash.from_xml(xml))
+      raise "No valid method response!" unless parsing_xml['methodName'].nil?
+      parsing_xml = parsing_xml['methodResponse']
+      if parsing_xml['fault'] != nil
+        # is a fault structure
+        [false, parsing_xml['fault']]
+      else
+        # is a normal return value
+        raise "Missing return value!" if parsing_xml['params'].length == 0
+        raise "Too many return values. Only one allowed!" if parsing_xml['params'].length > 1
+        [true, parsing_xml['params']['param']]
+      end
     end
 
     module Encoder


### PR DESCRIPTION
- Avoid the tag "params" when no arguments are passed to the method "method_call".
- Added some validations and modified the response in the "parse" method.