### PR TITLE
Avoid memory exhaustion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ end
 group :production do
   gem 'thin'
   gem 'rails_12factor'
+  gem 'unicorn-worker-killer'
 end
 
 gem 'mongoid'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,7 @@ GEM
       thor (~> 0.14)
     font-awesome-rails (4.6.2.0)
       railties (>= 3.2, < 5.1)
+    get_process_mem (0.2.3)
     glebtv_mongoid_userstamp (0.6.2)
       mongoid (>= 4.0.0, < 6.1)
       request_store
@@ -548,6 +549,9 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    unicorn-worker-killer (0.4.4)
+      get_process_mem (~> 0)
+      unicorn (>= 4, < 6)
     wannabe_bool (0.3.0)
     warden (1.2.3)
       rack (>= 1.0)
@@ -661,6 +665,7 @@ DEPENDENCIES
   thin
   uglifier
   unicorn (= 4.9.0)
+  unicorn-worker-killer
   wannabe_bool
   wicked_pdf
   wkhtmltopdf-binary

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,29 @@
 # This file is used by Rack-based servers to start the application.
 
+# Improves site's stability by avoiding unexpected memory exhaustion at the application nodes
+# https://www.digitalocean.com/community/tutorials/how-to-optimize-unicorn-workers-in-a-ruby-on-rails-app
+#
+# --- Start of unicorn worker killer code ---
+
+if ENV['RAILS_ENV'] == 'production' 
+  require 'unicorn/worker_killer'
+
+  max_request_min =  500
+  max_request_max =  600
+
+  # Max requests per worker
+  use Unicorn::WorkerKiller::MaxRequests, max_request_min, max_request_max
+
+  min_limit = (240) * (1024**2)
+  max_limit = (260) * (1024**2)
+
+  # Max memory size (RSS) per worker
+  # The actual limit is a rand(min_limit, max_limit)
+  # https://github.com/kzk/unicorn-worker-killer
+  use Unicorn::WorkerKiller::Oom, min_limit, max_limit
+end
+
+# --- End of unicorn worker killer code ---
+
 require ::File.expand_path('../config/environment',  __FILE__)
 run Rails.application


### PR DESCRIPTION
unicorn-worker-killer gem provides automatic restart of Unicorn workers based on

1) max number of requests, and 
2) process memory size (RSS), without affecting any requests.

This will greatly improve the site's stability by avoiding unexpected memory exhaustion at the application nodes.

See more in:

[how-to-optimize-unicorn-workers-in-a-ruby-on-rails-app](https://www.digitalocean.com/community/tutorials/how-to-optimize-unicorn-workers-in-a-ruby-on-rails-app)