### PR TITLE
[Rubocop] Fix Style/NumericPredicate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,6 @@ Metrics/LineLength:
 
 Style/EmptyLinesAroundClassBody:
   EnforcedStyle: false
+
+Style/NumericPredicate:
+  AutoCorrect: true

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rails_layout'
   gem 'ffaker'
-#  gem 'rubocop', '0.49.0'
+  gem 'rubocop', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,6 +370,7 @@ GEM
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
     polyglot (0.3.5)
+    powerpack (0.1.2)
     prawn (2.0.2)
       pdf-core (~> 0.6.0)
       ttfunk (~> 1.4.0)
@@ -433,6 +434,8 @@ GEM
       activesupport (= 4.2.7.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.2.2)
+      rake
     raindrops (0.15.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
@@ -477,7 +480,14 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.0)
+    rubocop (0.46.0)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-ole (1.2.12)
+    ruby-progressbar (1.10.0)
     ruby-rc4 (0.1.5)
     ruby_parser (3.7.2)
       sexp_processor (~> 4.1)
@@ -543,6 +553,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    unicode-display_width (1.5.0)
     unicorn (4.9.0)
       kgio (~> 2.6)
       rack
@@ -648,6 +659,7 @@ DEPENDENCIES
   rmagick (= 2.15.4)
   rolify
   rspec-rails
+  rubocop
   rubyzip
   rufus-scheduler
   sass-rails

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -21,7 +21,7 @@ module Api::V1
             end
             if (limit = @criteria.delete(:limit))
               limit = limit.to_s.to_i
-              limit = nil if limit == 0
+              limit = nil if limit.zero?
             end
             items = accessible_records.where(@criteria)
             if sort_key

--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -40,7 +40,7 @@ module Api::V2
           @render_options[:max_entries] =
             if (max_entries = @render_options[:max_entries])
               max_entries = max_entries.to_i
-              if max_entries == 0 || max_entries > maximum_entries
+              if max_entries.zero? || max_entries > maximum_entries
                 maximum_entries
               else
                 max_entries

--- a/app/controllers/api/v3/api_controller.rb
+++ b/app/controllers/api/v3/api_controller.rb
@@ -52,7 +52,7 @@ module Api::V3
       template_options[:max_entries] =
         if (max_entries = template_options[:max_entries])
           max_entries = max_entries.to_i
-          if max_entries == 0 || max_entries > maximum_entries
+          if max_entries.zero? || max_entries > maximum_entries
             maximum_entries
           else
             max_entries
@@ -62,7 +62,7 @@ module Api::V3
         end
       items = select_items
       items_data =
-        if get_limit == 0
+        if get_limit.zero?
           []
         else
           items.map do |item|
@@ -80,7 +80,7 @@ module Api::V3
           (template_options[:raw_properties] ? :_id : :id) => klass.data_type.id.to_s
         }
       }
-      if get_limit > 0
+      if get_limit.positive?
         json[:total_pages] = (count * 1.0 / get_limit).ceil
       end
       render json: json
@@ -336,7 +336,7 @@ module Api::V3
         begin
           limit_option = query_options.delete(:limit)
           limit = (query_selector.delete(:limit) || limit_option || Kaminari.config.default_per_page).to_i
-          if limit < 0
+          if limit.negative?
             Kaminari.config.default_per_page
           else
             [Kaminari.config.default_per_page, limit].min

--- a/app/controllers/rails_admin/main_controller_decorator.rb
+++ b/app/controllers/rails_admin/main_controller_decorator.rb
@@ -156,7 +156,7 @@ module RailsAdmin
           count += 1
         end
       end
-      if (count = messages.length - count) > 0
+      if (count = messages.length - count).positive?
         flash_message += "<br>- and another #{count}.".html_safe
       end
       flash_hash[flash_key] = flash_message.html_safe

--- a/app/helpers/rails_admin/application_helper_decorator.rb
+++ b/app/helpers/rails_admin/application_helper_decorator.rb
@@ -17,7 +17,7 @@ module RailsAdmin
       if parent == :root
         limit = 0
       end
-      if (limited = limit > 0)
+      if (limited = limit.positive?)
         count_links = 0
         more_actions_links = []
         current_action = nil
@@ -131,7 +131,7 @@ module RailsAdmin
         "<i class='icon-check' title='#{abstract_model.config.label_plural}' rel='tooltip'></i>".html_safe
       end.html_safe
       all_links << auth_link
-      if (unauthorized_count = Setup::Authorization.where(authorized: false).count) > 0
+      if (unauthorized_count = Setup::Authorization.where(authorized: false).count).positive?
         a = index_path(model_name: abstract_model.to_param, 'utf8' => '✓', 'f' => { 'authorized' => { '60852' => { 'v' => 'false' } } })
         counter_link = link_to a, class: 'pjax', title: "#{unauthorized_count} #{'unauthorized'.pluralize(unauthorized_count)}" do
           ('<b class="label rounded label-xs up counter red">' + unauthorized_count.to_s + '</b>').html_safe
@@ -153,13 +153,13 @@ module RailsAdmin
       counters = Hash.new { |h, k| h[k] = 0 }
       Setup::SystemNotification.type_enum.each do |type|
         scope = Setup::SystemNotification.where(type: type)
-        if (scope.count > 0)
+        if (scope.count.positive?)
           meta = account.meta
           if meta.present? && (from_date = meta["#{type.to_s}_notifications_listed_at"])
             scope = scope.where(:created_at.gte => from_date)
           end
           count = scope.count
-          if (count > 0)
+          if (count.positive?)
             counters[type] = count
           end
         end
@@ -334,7 +334,7 @@ module RailsAdmin
       nav_groups.each do |navigation_label, nav_nodes|
         ecoindex -= 1
         nav_nodes.group_by do |node|
-          if ecoindex == 0
+          if ecoindex.zero?
             Setup::CrossSharedCollection
           else
             ((data_type = node.abstract_model.model.try(:data_type)) && data_type.class) || Setup::CenitDataType
@@ -371,8 +371,8 @@ module RailsAdmin
               end
             end
           end
-          just_li = ecoindex == 0 || (@dashboard_group && @dashboard_group[:label] == label)
-          nodes = nodes.select { |n| n.parent.nil? || !n.parent.to_s.in?(node_model_names) } if ecoindex > 0
+          just_li = ecoindex.zero? || (@dashboard_group && @dashboard_group[:label] == label)
+          nodes = nodes.select { |n| n.parent.nil? || !n.parent.to_s.in?(node_model_names) } if ecoindex.positive?
           li_stack = navigation(nodes_stack, nodes, collapse_id, just_li: just_li, before_lis: before_lis, after_lis: after_lis)
 
           html_id = "main-#{label.underscore.gsub(' ', '-')}"
@@ -515,7 +515,7 @@ module RailsAdmin
             end
           Setup::Category.all.each do |cat|
             count = (values = Setup::CrossSharedCollection.where(category_ids: cat.id)).count
-            if count > 0
+            if count.positive?
               category_count += count
               message = "<span><em>#{node.label_plural}</em> with category <em>#{cat.title}</em></span>"
               filter_token = Cenit::Token.where('data.category_id' => cat.id).first || Cenit::Token.create(data: { criteria: values.selector, message: message, category_id: cat.id })
@@ -523,7 +523,7 @@ module RailsAdmin
                 sub_link_url = index_path(model_name: node.abstract_model.to_param, filter_token: filter_token.token)
                 link_to sub_link_url, class: 'pjax' do
                   rc = ''
-                  if model_count > 0
+                  if model_count.positive?
                     rc += "<span class='nav-amount active'>#{count}</span>"
                   end
                   rc += "<span class='text'>#{cat.title}</span>"
@@ -1126,7 +1126,7 @@ module RailsAdmin
           fail "invalid JSON content on #{file_name} (#{ex.message})"
         end
       else
-        if (list = count_apis)[:total] > 0
+        if ((list = count_apis)[:total]).positive?
           File.open(file_name, 'w') { |file| file.write(list.to_json) }
         end
         list
@@ -1158,7 +1158,7 @@ module RailsAdmin
       categories_count = []
       categories_list.each do |cat|
         count = apis.count { |c| c['categories'].include?(cat) }
-        if count > 0
+        if count.positive?
           cat['count'] = count
           categories_count << cat
         end

--- a/app/helpers/rails_admin/dashboard_helper.rb
+++ b/app/helpers/rails_admin/dashboard_helper.rb
@@ -1,7 +1,7 @@
 module RailsAdmin
   module DashboardHelper
     def percent(count = 0, max)
-      count > 0 ? (max <= 1 ? count : ((Math.log(count+1) * 100.0) / Math.log(max+1)).to_i) : -1
+      count.positive? ? (max <= 1 ? count : ((Math.log(count+1) * 100.0) / Math.log(max+1)).to_i) : -1
     end
 
     def animate_length(percent)
@@ -112,25 +112,25 @@ module RailsAdmin
 
     def task_monitor_data tasks
       _, am, _ = linking(Setup::Task)
-      if (value = tasks[:failed]) > 0
+      if (value = tasks[:failed]).positive?
         value = number_to_human(value)
         label = 'failed'
-      elsif (value = tasks[:broken]) > 0
+      elsif (value = tasks[:broken]).positive?
         value = number_to_human(value)
         label = 'broken'
-      elsif (value = tasks[:unscheduled]) > 0
+      elsif (value = tasks[:unscheduled]).positive?
         value = number_to_human(value)
         label = 'unscheduled'
-      elsif (value = tasks[:pending]) > 0
+      elsif (value = tasks[:pending]).positive?
         value = number_to_human(value)
         label = 'pending'
-      elsif (value = tasks[:retrying]) > 0
+      elsif (value = tasks[:retrying]).positive?
         value = number_to_human(value)
         label = 'retrying'
-      elsif (value = tasks[:paused]) > 0
+      elsif (value = tasks[:paused]).positive?
         value = number_to_human(value)
         label = 'paused'
-      elsif (value = tasks[:running]) > 0
+      elsif (value = tasks[:running]).positive?
         value = number_to_human(value)
         label = 'running'
       else
@@ -161,7 +161,7 @@ module RailsAdmin
 
     def auth_monitor_data auth
       _, am, _ = linking(Setup::Authorization)
-      if (value = auth[:unauthorized]) == 0
+      if (value = auth[:unauthorized]).zero?
         value = auth[:total]
         label = 'total'
       else
@@ -186,16 +186,16 @@ module RailsAdmin
 
     def notif_monitor_data notif
       _, am, _ = linking(Setup::SystemNotification)
-      if (value = notif[:error]) > 0
+      if (value = notif[:error]).positive?
         value = number_to_human(value)
         label = 'errors'
-      elsif (value = notif[:warning]) > 0
+      elsif (value = notif[:warning]).positive?
         value = number_to_human(value)
         label = 'warnings'
-      elsif (value = notif[:notice]) > 0
+      elsif (value = notif[:notice]).positive?
         value = number_to_human(value)
         label = 'notice'
-      elsif (value = notif[:info]) > 0
+      elsif (value = notif[:info]).positive?
         value = number_to_human(value)
         label = 'info'
       else

--- a/app/helpers/rails_admin/trace_helper.rb
+++ b/app/helpers/rails_admin/trace_helper.rb
@@ -44,7 +44,7 @@ module RailsAdmin
     def diffstat(additions, deletions, resume = false)
       blocks = ''
       added, deleted =
-        if (total = additions + deletions) > 0
+        if (total = additions + deletions).positive?
           if total <= 5
             [additions, deletions]
           else
@@ -54,22 +54,22 @@ module RailsAdmin
           [0, 0]
         end
       neutral = 5-(added + deleted)
-      while added > 0
+      while added.positive?
         blocks += '<span class="block-diff-added"></span>'
         added = added -1
       end
-      while deleted > 0
+      while deleted.positive?
         blocks += '<span class="block-diff-deleted"></span>'
         deleted = deleted -1
       end
-      while neutral > 0
+      while neutral.positive?
         blocks += '<span class="block-diff-neutral"></span>'
         neutral = neutral -1
       end
       title, prefix =
         if resume
-          additions_resume = additions > 0 ? %(<span class="additions">+ #{additions} </span>) : ''
-          deletions_resume = deletions > 0 ? %(<span class="deletions">- #{deletions} </span>) : ''
+          additions_resume = additions.positive? ? %(<span class="additions">+ #{additions} </span>) : ''
+          deletions_resume = deletions.positive? ? %(<span class="deletions">- #{deletions} </span>) : ''
           ["#{additions + deletions} changes", %(#{additions_resume}#{deletions_resume})]
         else
           ["#{additions} additions &amp; #{deletions} deletions", additions+deletions]
@@ -135,7 +135,7 @@ module RailsAdmin
                     deletions += diff[:deletions]
                     diff[:html]
                   end
-                tab_pane = "<div class='tab-pane#{index == 0 ? ' active' : ''}' id='unique_id_#{id}'>#{content}</div>"
+                tab_pane = "<div class='tab-pane#{index.zero? ? ' active' : ''}' id='unique_id_#{id}'>#{content}</div>"
                 tab_pane
               end.join
               first = true
@@ -178,7 +178,7 @@ module RailsAdmin
             {
               additions: additions,
               deletions: deletions,
-              html: additions + deletions > 0 ? diff.to_s(:html) : %(#{diffstat(0, 0)}<label class="label label-default">Unchanged<label>)
+              html: (additions + deletions).positive? ? diff.to_s(:html) : %(#{diffstat(0, 0)}<label class="label label-default">Unchanged<label>)
             }
           end
       end

--- a/app/models/cenit/oauth_scope.rb
+++ b/app/models/cenit/oauth_scope.rb
@@ -53,7 +53,7 @@ module Cenit
             openid_expected = false
             i = 1
             stack = 1
-            while stack > 0 && i < scope.length
+            while stack.positive? && i < scope.length
               case scope[i]
               when '{'
                 stack += 1

--- a/app/models/concerns/fields_inspection.rb
+++ b/app/models/concerns/fields_inspection.rb
@@ -30,7 +30,7 @@ module FieldsInspection
   module ClassMethods
 
     def inspect_fields(*args)
-      if args.length > 0
+      if args.length.positive?
         @inspecting_fields = args.collect(&:to_s).collect(&:to_sym)
       end
       @inspecting_fields || []

--- a/app/models/rails_admin/abstract_model_decorator.rb
+++ b/app/models/rails_admin/abstract_model_decorator.rb
@@ -40,7 +40,7 @@ module RailsAdmin
       unless (path = config.api_path)
         tokens = @model_name.split('::')
         path = tokens.pop.underscore
-        if tokens.length > 0
+        if tokens.length.positive?
           path = tokens.collect(&:underscore).join('/') + "/#{path}"
         else
           path = "#{Setup.to_s.underscore}/#{path}"

--- a/app/models/rails_admin/config/model_decorator.rb
+++ b/app/models/rails_admin/config/model_decorator.rb
@@ -34,7 +34,7 @@ module RailsAdmin
       end
 
       def filter_fields(*args)
-        if args.length == 0
+        if args.length.zero?
           if (names = filter_fields_names)
             _fields.select { |f| names.include?(f.name) }
           else
@@ -52,7 +52,7 @@ module RailsAdmin
       end
 
       def filter_query_fields(*args)
-        if args.length == 0
+        if args.length.zero?
           if (names = filter_query_fields_names)
             fields.select { |f| names.include?(f.name) }
           else

--- a/app/models/setup/api_spec.rb
+++ b/app/models/setup/api_spec.rb
@@ -84,7 +84,7 @@ module Setup
 
         parameters.each { |param| fail I18n.t('cenit.api_spec.swagger_parser.error.parameter_name_conflict', param: param) if definitions.key?(param) }
 
-        if definitions.size > 0
+        if definitions.size.positive?
           definitions.each_pair do |name, schema|
             schema['type'] = 'object' if schema['properties'] && schema['type'].nil?
             schema['title'] = name
@@ -285,7 +285,7 @@ module Setup
           end
         end
 
-        if definitions.size > 0 || parameters.size > 0
+        if definitions.size.positive? || parameters.size.positive?
           data['snippets'] = snippets = []
           data['data_types'] = data_types = []
           {

--- a/app/models/setup/authorization.rb
+++ b/app/models/setup/authorization.rb
@@ -71,7 +71,7 @@ module Setup
       def method_missing(symbol, *args)
         if CONFIG_FIELDS.any? { |field| "auth_#{field.pluralize}" == symbol.to_s }
           ivar = "@#{symbol}".to_sym
-          instance_variable_set(ivar, args[0].stringify_keys) if args.length > 0
+          instance_variable_set(ivar, args[0].stringify_keys) if args.length.positive?
           value = instance_variable_get(ivar) || {}
           if superclass == Object
             value

--- a/app/models/setup/class_hierarchy_aware.rb
+++ b/app/models/setup/class_hierarchy_aware.rb
@@ -26,7 +26,7 @@ module ClassHierarchyAware
       end
 
       def abstract_class(*args)
-        @abstract_class = args[0].present? if args.length > 0
+        @abstract_class = args[0].present? if args.length.positive?
         @abstract_class
       end
 

--- a/app/models/setup/cross_shared_collection.rb
+++ b/app/models/setup/cross_shared_collection.rb
@@ -355,7 +355,7 @@ module Setup
     def method_missing(symbol, *args)
       if (match = /\Adata_(.+)\Z/.match(symbol.to_s)) &&
         COLLECTING_PROPERTIES.include?(relation_name = match[1].to_sym) &&
-        ((args.length == 0 && (options = {})) || args.length == 1 && (options = args[0]).is_a?(Hash))
+        ((args.length.zero? && (options = {})) || args.length == 1 && (options = args[0]).is_a?(Hash))
         if (items = send(relation_name)).present?
           items
         else

--- a/app/models/setup/data_type.rb
+++ b/app/models/setup/data_type.rb
@@ -51,7 +51,7 @@ module Setup
         by_name = Hash.new { |h, k| h[k] = 0 }
         send(methods).each do |method|
           by_name[method.name] += 1
-          if method.parameters.size == 0
+          if method.parameters.size.zero?
             errors.add(methods, "contains algorithm taking no parameter: #{method.custom_title} (at less one parameter is required)")
           end
         end

--- a/app/models/setup/notification.rb
+++ b/app/models/setup/notification.rb
@@ -38,7 +38,7 @@ module Setup
 
     class << self
       def transformation_types(*args)
-        if args.length > 0
+        if args.length.positive?
           @transformation_types = args.flatten
         else
           @transformation_types || (superclass.is_a?(Setup::Notification) ? superclass.transformation_types : [])

--- a/app/models/setup/scheduler.rb
+++ b/app/models/setup/scheduler.rb
@@ -256,9 +256,9 @@ module Setup
       if @conf[:type] == 'appointed_position'
         months_days = []
         # Retrieve days by weeks
-        if weeks_month.length > 0
+        if weeks_month.length.positive?
           weeks_month.each do |wm|
-            if wm > 0
+            if wm.positive?
               # firsts one
               months_days += weeks_days.collect { |wd| weeks_first_days(@year, wd, month)[wm - 1] }
             else
@@ -277,7 +277,7 @@ module Setup
 
       months_days = (1..a).to_a if months_days.blank?
 
-      months_days.select { |e| e > 0 && e <= a }
+      months_days.select { |e| e.positive? && e <= a }
     end
 
     def hours
@@ -295,7 +295,7 @@ module Setup
     def months
       res = @conf[:months]
       res = (1..12).to_a if res.blank?
-      res.select { |e| e > 0 && e <= 12 }
+      res.select { |e| e.positive? && e <= 12 }
     end
 
     def initialize(conf, year, tz)

--- a/app/models/setup/singleton.rb
+++ b/app/models/setup/singleton.rb
@@ -3,7 +3,7 @@ module Setup
     extend ActiveSupport::Concern
 
     def save(options = {})
-      fail "Only one record is allowed for #{self.class}" if new_record? && self.class.count > 0
+      fail "Only one record is allowed for #{self.class}" if new_record? && self.class.count.positive?
       super
     end
 

--- a/app/models/setup/slug.rb
+++ b/app/models/setup/slug.rb
@@ -21,7 +21,7 @@ module Setup
             candidate.squeeze(' ').tr(' ', '_')
           end
         i = candidate.length - 1
-        while candidate.length > 0 && i == candidate.length - 1
+        while candidate.length.positive? && i == candidate.length - 1
           i -= 1 while i >= 0 && candidate[i] =~ /\A\.|[a-z]|[A-Z]|\d|_\Z/
           if i == candidate.length - 1
             candidate = candidate.to(i - 1)

--- a/app/models/setup/snippet_code.rb
+++ b/app/models/setup/snippet_code.rb
@@ -145,7 +145,7 @@ module Setup
       end
 
       def legacy_code_attribute(*args)
-        if args.length == 0
+        if args.length.zero?
           @legacy_code_attribute
         else
           @legacy_code_attribute = args[0].to_s

--- a/app/models/setup/system_notification.rb
+++ b/app/models/setup/system_notification.rb
@@ -87,7 +87,7 @@ module Setup
             end
           total_count = 0
           Setup::SystemNotification.type_enum.each do |type|
-            if (count = scope.where(type: type).count) > 0
+            if (count = scope.where(type: type).count).positive?
               total_count += count
               counters[Setup::SystemNotification.type_color(type)] = count
             end

--- a/app/models/setup/task.rb
+++ b/app/models/setup/task.rb
@@ -336,7 +336,7 @@ module Setup
       end
 
       def agent_field(*args)
-        if args.length > 0
+        if args.length.positive?
           @agent_field = args[0]
         else
           @agent_field || superclass.try(:agent_field)

--- a/app/models/setup/translator.rb
+++ b/app/models/setup/translator.rb
@@ -80,7 +80,7 @@ module Setup
       end
 
       def transformation_type(*args)
-        if args.length > 0
+        if args.length.positive?
           @transformation_type = args[0].to_s.to_sym
         end
         @transformation_type || (superclass < Translator ? superclass.transformation_type : nil)

--- a/config/initializers/cancan_monkey_patch.rb
+++ b/config/initializers/cancan_monkey_patch.rb
@@ -11,7 +11,7 @@ module CanCan
     class MongoidAdapter
 
       def database_records
-        if @rules.size == 0
+        if @rules.size.zero?
           @model_class.where(:_id => {'$exists' => false, '$type' => 7})
         elsif @rules.size == 1 && @rules[0].conditions.is_a?(Mongoid::Criteria)
           @rules[0].conditions

--- a/config/initializers/cross_origin.rb
+++ b/config/initializers/cross_origin.rb
@@ -35,7 +35,7 @@ module CrossOrigin
       end
 
       def origins(*args)
-        if args.length == 0
+        if args.length.zero?
           origins = []
           acc = ::Account.current
           super.each do |origin|

--- a/config/initializers/diffy_monkey_patch.rb
+++ b/config/initializers/diffy_monkey_patch.rb
@@ -15,12 +15,12 @@ module Diffy
             unchanged_lines << l
           else
             if unchanged_lines.length > min_count_collapse
-              first = (all_lines.length == 0)
+              first = (all_lines.length.zero?)
               last = (idx +1 == lines.length)
               all_lines.concat(wrapped_collapse(unchanged_lines, first, last))
               unchanged_lines= []
             else
-              if unchanged_lines.length > 0
+              if unchanged_lines.length.positive?
                 all_lines.concat(unchanged_lines)
                 unchanged_lines= []
               end
@@ -28,7 +28,7 @@ module Diffy
             all_lines << l
           end
         end
-        if (unchained_count = unchanged_lines.length) > 0
+        if (unchained_count = unchanged_lines.length).positive?
           if unchained_count > min_count_collapse
             first = false
             last = true

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -51,7 +51,7 @@ after_fork do |server, worker|
   defined?(ActiveRecord::Base) and ActiveRecord::Base.establish_connection
   defined?(Rails) and Rails.cache.respond_to?(:reconnect) and Rails.cache.reconnect
 
-  if worker.nr == 0
+  if worker.nr.zero?
     Cenit::Rabbit.start_scheduler
     Tenant.all.each do |tenant|
       tenant.switch do

--- a/lib/cenit/cenit.rb
+++ b/lib/cenit/cenit.rb
@@ -29,7 +29,7 @@ module Cenit
     end
 
     def excluded_actions(*args)
-      if args.length == 0
+      if args.length.zero?
         options[:excluded_actions]
       else
         self[:excluded_actions] = args.flatten.collect(&:to_s).join(' ').split(' ').collect(&:to_sym)
@@ -37,7 +37,7 @@ module Cenit
     end
 
     def reserved_namespaces(*args)
-      if args.length == 0
+      if args.length.zero?
         options[:reserved_namespaces]
       else
         self[:reserved_namespaces] = (options[:reserved_namespaces] + args[0].flatten.collect(&:to_s).collect(&:downcase)).uniq
@@ -49,7 +49,7 @@ module Cenit
     end
 
     def default_file_store(*args)
-      if args.length == 0
+      if args.length.zero?
         options[:default_file_store] || file_stores.first
       else
         default_file_store =
@@ -70,7 +70,7 @@ module Cenit
     end
 
     def file_stores(*args)
-      if args.length == 0
+      if args.length.zero?
         options[:file_stores] || [options.key?(:default_file_store) ? default_file_store : Cenit::FileStore::LocalDb]
       else
         args = args.flatten
@@ -83,7 +83,7 @@ module Cenit
     end
 
     def file_stores_roles(*args)
-      if args.length == 0
+      if args.length.zero?
         options[:file_stores_roles]
       else
         self[:file_stores_roles] = args.flatten.collect(&:to_s)

--- a/lib/cenit/file_store/base.rb
+++ b/lib/cenit/file_store/base.rb
@@ -12,7 +12,7 @@ module Cenit
       end
 
       def read(file, *args)
-        len = (args.length > 0 && args[0].to_i) || file.length || 0
+        len = (args.length.positive? && args[0].to_i) || file.length || 0
         if (stash_data = file.stash_data)
           if stash_data.is_a?(String)
             cursor = file.cursor

--- a/lib/cenit/file_store/local_db.rb
+++ b/lib/cenit/file_store/local_db.rb
@@ -72,7 +72,7 @@ module Cenit
       end
 
       def stored?(file)
-        chunks(file).count > 0
+        chunks(file).count.positive?
       end
 
       private
@@ -109,7 +109,7 @@ module Cenit
       end
 
       def chunking(io, chunk_size, &block)
-        if io.method(:read).arity == 0
+        if io.method(:read).arity.zero?
           data = io.read
           i = 0
           loop do
@@ -123,7 +123,7 @@ module Cenit
             i += 1
           end
         else
-          while (buf = io.read(chunk_size)) && buf.size > 0
+          while (buf = io.read(chunk_size)) && buf.size.positive?
             block.call(buf)
           end
         end

--- a/lib/cenit/xmlrpc.rb
+++ b/lib/cenit/xmlrpc.rb
@@ -29,7 +29,7 @@ module Cenit
         [false, parsing_xml['fault']]
       else
         # is a normal return value
-        fail 'Missing return value!' if parsing_xml['params'].length == 0
+        fail 'Missing return value!' if parsing_xml['params'].length.zero?
         fail 'Too many return values. Only one allowed!' if parsing_xml['params'].length > 1
         [true, parsing_xml['params']['param']]
       end

--- a/lib/edi/formater.rb
+++ b/lib/edi/formater.rb
@@ -22,7 +22,7 @@ module Edi
     def default_hash(options = {})
       prepare_options(options)
       max_entries = options[:max_entries].to_i
-      max_entries = nil if max_entries == 0
+      max_entries = nil if max_entries.zero?
       hash = record_to_hash(self_record, options, options.delete(:reference), nil, max_entries, options[:viewport].presence)
       options.delete(:stack)
       hash = { self_record.orm_model.data_type.slug => hash } if options[:include_root]
@@ -396,7 +396,7 @@ module Edi
           if (value = record.send(property_name))
             next if max_entries && value.size > max_entries
             sub_max_entries = max_entries && (max_entries - value.size)
-            sub_max_entries = 1 unless sub_max_entries.nil? || sub_max_entries > 0
+            sub_max_entries = 1 unless sub_max_entries.nil? || sub_max_entries.positive?
             new_value = []
             value.each do |sub_record|
               next if inspecting && (scope = options[:inspect_scope]) && !scope.include?(sub_record)

--- a/lib/edi/parser.rb
+++ b/lib/edi/parser.rb
@@ -287,7 +287,7 @@ module Edi
               property_schema = data_type.merge_schema(property_schema)
               name = property_schema['edi']['segment'] if property_schema['edi']
               name ||= property_name
-              name = name.split(':').last if phase > 0
+              name = name.split(':').last if phase.positive?
               next if taken_items.include?(name)
               property_model = model.property_model(property_name)
               taken_items << property_name if json.has_key?(name)
@@ -449,7 +449,7 @@ module Edi
           end
         if !edi_options['virtual']
           return [nil, start, nil] unless start < content.length && content[start, seg_id.length] == seg_id
-          if (fields_count = model.properties_schemas.count { |property, schema| !model.property_model?(property) && (!schema['edi'] || !schema['edi']['discard']) }) == 0
+          if (fields_count = model.properties_schemas.count { |property, schema| !model.property_model?(property) && (!schema['edi'] || !schema['edi']['discard']) }).zero?
             segment_sep ||= content[start + seg_id.length]
           else
             field_sep ||= content[start + seg_id.length]
@@ -478,8 +478,8 @@ module Edi
                 raise Exception.new('Can not infers segment separator without EDI segment metadata in next sub-segment schema') unless next_seg_schema['edi'] && next_seg_id = next_seg_schema['edi']['segment']
                 puts "Inferring segment separator with field separator #{field_sep}..."
                 cursor = start + seg_id.length + 1
-                if fields_count > 0
-                  while fields_count > 0
+                if fields_count.positive?
+                  while fields_count.positive?
                     cursor = content.index(field_sep, cursor) + 1
                     fields_count -= 1
                   end

--- a/lib/json-schema/attributes/formats/uint_format.rb
+++ b/lib/json-schema/attributes/formats/uint_format.rb
@@ -5,7 +5,7 @@ module JSON
       class << self
 
         def bits(*args)
-          if args.length == 0
+          if args.length.zero?
             @bits
           else
             unless %w(32 64).include? (@bits = args[0].to_i).to_s

--- a/lib/json-schema/attributes/mongoff_properties_attribute.rb
+++ b/lib/json-schema/attributes/mongoff_properties_attribute.rb
@@ -61,7 +61,7 @@ module JSON
             end
           end
 
-          if diff.size > 0
+          if diff.size.positive?
             properties = diff.keys.join(', ')
             message = "The property '#{build_fragment(fragments)}' contained undefined properties: '#{properties}'"
             validation_error(processor, message, fragments, current_schema, self, options[:record_errors])

--- a/lib/mongoff/model.rb
+++ b/lib/mongoff/model.rb
@@ -419,9 +419,9 @@ module Mongoff
       end
 
       def method_missing(symbol, *args)
-        if !symbol.to_s.end_with?('=') && ((args.length == 0 && block_given?) || args.length == 1 && !block_given?)
+        if !symbol.to_s.end_with?('=') && ((args.length.zero? && block_given?) || args.length == 1 && !block_given?)
           self[symbol] = block_given? ? yield : args[0]
-        elsif args.length == 0 && !block_given?
+        elsif args.length.zero? && !block_given?
           self[symbol]
         else
           super

--- a/lib/mongoff/validator.rb
+++ b/lib/mongoff/validator.rb
@@ -143,7 +143,7 @@ module Mongoff
 
     def check_schema_multipleOf(value)
       _check_type(:multipleOf, value, Numeric)
-      raise "Invalid value for multipleOf, strictly greater than zero is expected" unless value > 0
+      raise "Invalid value for multipleOf, strictly greater than zero is expected" unless value.positive?
     end
 
     def check_multipleOf(value, instance)
@@ -188,7 +188,7 @@ module Mongoff
 
     def check_schema_maxLength(value)
       _check_type(:maxLength, value, Integer)
-      raise "Invalid value for maxLength, a non negative value is expected" if value < 0
+      raise "Invalid value for maxLength, a non negative value is expected" if value.negative?
     end
 
     def check_maxLength(value, instance)
@@ -197,7 +197,7 @@ module Mongoff
 
     def check_schema_minLength(value)
       _check_type(:maxLength, value, Integer)
-      raise "Invalid value for minLength, a non negative value is expected" if value < 0
+      raise "Invalid value for minLength, a non negative value is expected" if value.negative?
     end
 
     def check_minLength(value, instance)
@@ -252,7 +252,7 @@ module Mongoff
 
     def check_schema_maxItems(max)
       _check_type(:maxItems, max, Integer)
-      raise "Invalid value for maxItems, a non negative value is expected" if max < 0
+      raise "Invalid value for maxItems, a non negative value is expected" if max.negative?
     end
 
     def check_maxItems(max, items)
@@ -263,7 +263,7 @@ module Mongoff
 
     def check_schema_minItems(min)
       _check_type(:minItems, min, Integer)
-      raise "Invalid value for minItems, a non negative value is expected" if min < 0
+      raise "Invalid value for minItems, a non negative value is expected" if min.negative?
     end
 
     def check_minItems(min, items)
@@ -355,7 +355,7 @@ module Mongoff
 
     def check_schema_maxProperties(max)
       _check_type(:maxProperties, max, Integer)
-      raise "Invalid value for maxProperties, a non negative value is expected" if max < 0
+      raise "Invalid value for maxProperties, a non negative value is expected" if max.negative?
     end
 
     def check_maxProperties(max, instance)
@@ -367,7 +367,7 @@ module Mongoff
 
     def check_schema_minProperties(min)
       _check_type(:minProperties, min, Integer)
-      raise "Invalid value for minProperties, a non negative value is expected" if min < 0
+      raise "Invalid value for minProperties, a non negative value is expected" if min.negative?
     end
 
     def check_minProperties(min, instance)

--- a/lib/rails_admin/config/actions/base_delete_data_type.rb
+++ b/lib/rails_admin/config/actions/base_delete_data_type.rb
@@ -45,7 +45,7 @@ module RailsAdmin
                 @selector_token = Cenit::Token.create(data: scope.selector, token_span: 300).token
               end
               @object = Object.new
-              @object.instance_variable_set(:@_to_delete, scope) if scope.count > 0
+              @object.instance_variable_set(:@_to_delete, scope) if scope.count.positive?
               render :delete_data_types
             end
           end

--- a/lib/rails_admin/config/actions/compare.rb
+++ b/lib/rails_admin/config/actions/compare.rb
@@ -73,7 +73,7 @@ module RailsAdmin
                 base_record.fill_from(hash)
                 trace = ::Mongoid::Tracer::Trace.new(base_record.trace_action_attributes(:update))
                 @diff = build_diff(@abstract_model, trace.changes_set(base_trace))
-                unless @diff[:additions] + @diff[:deletions] > 0
+                unless (@diff[:additions] + @diff[:deletions]).positive?
                   @can_merge = @diff = nil
                 end
               end

--- a/lib/rails_admin/config/actions/delete_data_type.rb
+++ b/lib/rails_admin/config/actions/delete_data_type.rb
@@ -32,7 +32,7 @@ module RailsAdmin
               end
               redirect_to redirect_path
             else
-              @object.instance_variable_set(:@_to_delete, @object) if @object.count > 0
+              @object.instance_variable_set(:@_to_delete, @object) if @object.count.positive?
               render 'delete_data_types'
             end
           end

--- a/lib/rails_admin/config/actions/remote_shared_collection.rb
+++ b/lib/rails_admin/config/actions/remote_shared_collection.rb
@@ -63,7 +63,7 @@ module RailsAdmin
                         i += 1
                         new_name = "#{@response['name']}_remote_pull_#{i}"
                       end
-                      if i > 0
+                      if i.positive?
                         flash[:warning] = t('admin.actions.remote_shared_collection.pull_rename', model: @model_config.label, name: @response['name'], new_name: new_name)
                         @response['name'] = new_name
                       end

--- a/lib/rails_admin/config/fields/types/time_span.rb
+++ b/lib/rails_admin/config/fields/types/time_span.rb
@@ -13,7 +13,7 @@ module RailsAdmin
           end
 
           register_instance_option :pretty_value do
-            if (v = value) < 0
+            if (v = value).negative?
               negative_pretty_value
             else
               str = ''
@@ -30,7 +30,7 @@ module RailsAdmin
                 break if m == current_metric
               end
               h.each do |m, scale|
-                if (scaled_v = v / scale) > 0
+                if (scaled_v = v / scale).positive?
                   str = "#{v % scale}#{current_metric} #{str}"
                   v = scaled_v
                   current_metric = m

--- a/lib/rails_admin/lib/mongoff_property.rb
+++ b/lib/rails_admin/lib/mongoff_property.rb
@@ -110,7 +110,7 @@ module RailsAdmin
         end
       #Empty Test
       if !required? &&
-        ((((min = hash_schema['minLength']) && (min > 0 || (min == 0 && hash_schema['exclusiveMaximum']))) ||
+        ((((min = hash_schema['minLength']) && (min.positive? || (min.zero? && hash_schema['exclusiveMaximum']))) ||
           ((pattern = hash_schema['pattern']) && !''.match(pattern))))
 
         type = "non_empty_#{type}"

--- a/lib/rails_admin/models/setup/collection_fields_config_admin.rb
+++ b/lib/rails_admin/models/setup/collection_fields_config_admin.rb
@@ -262,92 +262,92 @@ module RailsAdmin
               field :name
               field :flows do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :connection_roles do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :translators do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :events do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :data_types do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :schemas do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :custom_validators do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :algorithms do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :applications do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :webhooks do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :connections do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :resources do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :operations do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :authorizations do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :oauth_providers do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :oauth_clients do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :generic_clients do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :oauth2_scopes do
                 pretty_value do
-                  value.count > 0 ? value.count : '-'
+                  value.count.positive? ? value.count : '-'
                 end
               end
               field :updated_at

--- a/lib/rails_admin/models/setup/legacy_translator_admin.rb
+++ b/lib/rails_admin/models/setup/legacy_translator_admin.rb
@@ -9,7 +9,7 @@ module RailsAdmin
             navigation_label 'Transforms'
             label 'Legacy Translator'
             visible do
-              group_visible && ::Setup::LegacyTranslator.count > 0
+              group_visible && ::Setup::LegacyTranslator.count.positive?
             end
             weight 414
             object_label_method { :custom_title }

--- a/lib/xsd/complex_type.rb
+++ b/lib/xsd/complex_type.rb
@@ -53,7 +53,7 @@ module Xsd
               'items' => container_schema
             }
           properties[p]['maxItems'] = container.max_occurs unless container.max_occurs == :unbounded
-          required << p if container.min_occurs > 0
+          required << p if container.min_occurs.positive?
         else
           container_required = container_schema['required'] || []
           if (container_properties = container_schema['properties']).size == 1

--- a/lib/xsd/container.rb
+++ b/lib/xsd/container.rb
@@ -31,7 +31,7 @@ module Xsd
       json = documenting('type' => 'object', 'title' => tag_name.to_title)
       json['properties'] = properties = {}
       required = []
-      if max_occurs == :unbounded || max_occurs > 0 || min_occurs > 1
+      if max_occurs == :unbounded || max_occurs.positive? || min_occurs > 1
         elements.each do |element|
           element_schema = element.to_json_schema
           if element.max_occurs == :unbounded || element.max_occurs > 1 || element.min_occurs > 1
@@ -42,7 +42,7 @@ module Xsd
                               'minItems' => element.min_occurs,
                               'items' => element_schema }
             properties[p]['maxItems'] = element.max_occurs unless element.max_occurs == :unbounded
-            required << p if element.min_occurs > 0
+            required << p if element.min_occurs.positive?
           elsif element.is_a?(Container)
             container_required = element_schema['required'] || []
             element_schema['properties'].each do |property, schema|


### PR DESCRIPTION

To review this PR is better to review each commit independently.

- add rubocop gem back to Gemfile 

- add Style/NumericPredicate to config file `.rubocop.yml`. Add option `Set AutoCorrect: true`

- Auto correct for Style/NumericPredicate, using from the root the next command:

   `rubocop --auto-correct --only Style/NumericPredicate`
    
  