### PR TITLE
Rubocop style hash syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,6 @@ Style/NumericPredicate:
 
 Style/AlignHash:
   Enabled: true
+
+Style/HashSyntax:
+  Enabled: true

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -3,12 +3,12 @@ module Api::V1
     before_action :authorize_account, :save_request_data, except: [:new_user, :cors_check, :auth]
     before_action :find_item, only: [:show, :destroy, :pull, :run]
     before_action :authorize_action, except: [:auth, :new_user, :cors_check, :push]
-    rescue_from Exception, :with => :exception_handler
+    rescue_from Exception, with: :exception_handler
     respond_to :json
 
     def cors_check
       self.cors_header
-      render :text => '', :content_type => 'text/plain'
+      render text: '', content_type: 'text/plain'
     end
 
     def index

--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -6,7 +6,7 @@ module Api::V2
     before_action :authorize_action, except: [:auth, :new_user, :cors_check, :push]
     before_action :find_item, only: [:update, :show, :destroy, :pull, :run, :retry, :authorize]
 
-    rescue_from Exception, :with => :exception_handler
+    rescue_from Exception, with: :exception_handler
 
     respond_to :json
 

--- a/app/controllers/api/v3/api_controller.rb
+++ b/app/controllers/api/v3/api_controller.rb
@@ -8,7 +8,7 @@ module Api::V3
     before_action :find_item, only: [:update, :show, :destroy, :digest]
     before_action :authorize_action, except: [:new_user, :cors_check]
 
-    rescue_from Exception, :with => :exception_handler
+    rescue_from Exception, with: :exception_handler
 
     respond_to :json
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from CanCan::AccessDenied, RailsAdmin::ActionNotAllowed do |exception|
     if _current_user
-      redirect_to main_app.root_path, :alert => exception.message
+      redirect_to main_app.root_path, alert: exception.message
     else
       redirect_to new_session_path(User)
     end

--- a/app/helpers/rails_admin/application_helper_decorator.rb
+++ b/app/helpers/rails_admin/application_helper_decorator.rb
@@ -874,7 +874,7 @@ module RailsAdmin
     def public_apis_collection_view(c)
       has_image = c.image.present?
       css_class = 'img-responsive ' + (has_image ? '' : 'no-image')
-      image = image_tag has_image ? c.image.versions[:thumb] : 'missing.png', :class => css_class, :alt => c.name, style: 'width: 80%'
+      image = image_tag has_image ? c.image.versions[:thumb] : 'missing.png', class: css_class, alt: c.name, style: 'width: 80%'
       url_show = rails_admin.show_path(model_name: c.model_name.to_s.underscore.gsub('/', '~'), id: c.name)
       '<div class="col-md-2 col-sm-3">
         <a href="' + url_show + '" title="' + c.name + '">
@@ -921,7 +921,7 @@ module RailsAdmin
     def dashboard_collection_view(c)
       has_image = c.image.present?
       css_class = 'img-responsive ' + (has_image ? '' : 'no-image')
-      image = image_tag has_image ? c.image.versions[:thumb] : 'missing.png', :class => css_class, :alt => c.name, width: '80%', max_height: '80%', margin: '12px'
+      image = image_tag has_image ? c.image.versions[:thumb] : 'missing.png', class: css_class, alt: c.name, width: '80%', max_height: '80%', margin: '12px'
       url_show = rails_admin.show_path(model_name: c.model_name.to_s.underscore.gsub('/', '~'), id: c.name)
       '<div class="col-xs-6 col-sm-4 col-md-2">
         <a href="' + url_show + '" title="' + c.name + '">

--- a/app/helpers/rails_admin/notebooks_helper.rb
+++ b/app/helpers/rails_admin/notebooks_helper.rb
@@ -23,7 +23,7 @@ module RailsAdmin
     end
 
     def index_setup_notebook
-      render :layout => 'rails_admin/application', :template => 'rails_admin/main/notebooks'
+      render layout: 'rails_admin/application', template: 'rails_admin/main/notebooks'
     end
 
     def show_setup_notebook

--- a/app/helpers/rails_admin/rest_api_helper.rb
+++ b/app/helpers/rails_admin/rest_api_helper.rb
@@ -12,12 +12,12 @@ module RailsAdmin
 
     def api_langs
       [
-        { id: 'curl', label: 'Curl', hljs: 'bash', :runnable => true },
-        { id: 'php', label: 'Php', hljs: 'php', :runnable => false },
-        { id: 'ruby', label: 'Ruby', hljs: 'ruby', :runnable => true },
-        { id: 'python', label: 'Python', hljs: 'python', :runnable => true },
-        { id: 'nodejs', label: 'Nodejs', hljs: 'javascript', :runnable => true },
-        { id: 'jquery', label: 'JQuery', hljs: 'javascript', :runnable => false },
+        { id: 'curl', label: 'Curl', hljs: 'bash', runnable: true },
+        { id: 'php', label: 'Php', hljs: 'php', runnable: false },
+        { id: 'ruby', label: 'Ruby', hljs: 'ruby', runnable: true },
+        { id: 'python', label: 'Python', hljs: 'python', runnable: true },
+        { id: 'nodejs', label: 'Nodejs', hljs: 'javascript', runnable: true },
+        { id: 'jquery', label: 'JQuery', hljs: 'javascript', runnable: false },
       ]
     end
 

--- a/app/mailers/contact_us/contact_mailer.rb
+++ b/app/mailers/contact_us/contact_mailer.rb
@@ -3,10 +3,10 @@ module ContactUs
     def contact_email(contact)
       @contact = contact
 
-      mail :from => (ContactUs.config.mailer_from || @contact.email),
-           :reply_to => @contact.email,
-           :subject => t('contact_us.contact_mailer.contact_email.subject', :email => @contact.email) + " #{@contact.subject}",
-           :to => ContactUs.config.mailer_to
+      mail from: (ContactUs.config.mailer_from || @contact.email),
+           reply_to: @contact.email,
+           subject: t('contact_us.contact_mailer.contact_email.subject', email: @contact.email) + " #{@contact.subject}",
+           to: ContactUs.config.mailer_to
     end
   end
 end

--- a/app/models/concerns/date_time_charts.rb
+++ b/app/models/concerns/date_time_charts.rb
@@ -7,7 +7,7 @@ module DateTimeCharts
       met = simple_properties_schemas.key?(base_calc.to_s) ? "map(&:#{base_calc})" : "send(:#{base_calc})" # TODO: Check aggregation calculation when base_calc is a relation
       proc = eval "lambda { |collection| collection.#{met}.#{calculation} }"
       set = acumulate =~ /^beginning_of/ ? set.map { |k, v| [k, proc.call(v)] } : set.sort.map { |c| [send(acumulate)[c[0]], proc.call(c[1])] }
-      [{ :data => set }]
+      [{ data: set }]
     end
 
     def wday

--- a/app/models/contact_us/contact.rb
+++ b/app/models/contact_us/contact.rb
@@ -9,11 +9,11 @@ module ContactUs
     field :subject, type: String
 
     validates :email,
-      :format => { :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i },
-      :presence => true
-    validates :message, :presence => true
-    validates :name, :presence => { :if => Proc.new { ContactUs.require_name } }
-    validates :subject, :presence => { :if => Proc.new { ContactUs.require_subject } }
+      format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i },
+      presence: true
+    validates :message, presence: true
+    validates :name, presence: { if: Proc.new { ContactUs.require_name } }
+    validates :subject, presence: { if: Proc.new { ContactUs.require_subject } }
 
     def save
       super

--- a/app/models/rails_admin/config/actions/index_decorator.rb
+++ b/app/models/rails_admin/config/actions/index_decorator.rb
@@ -18,7 +18,7 @@ module RailsAdmin
                 # to suggest a unique default filter name, Example: 'Util/Logs_filter_1'
                 prefix = "#{dt_name}_filter_"
                 reg_exp = Regexp.new("^#{Regexp.quote(prefix)}(\d+)")
-                filter_name = (last_filter = Setup::Filter.where(:name => reg_exp).sort(:created_at => 1).last) ? "#{prefix}#{last_filter.name.match(reg_exp)[1].to_i + 1}" : "#{prefix}1"
+                filter_name = (last_filter = Setup::Filter.where(name: reg_exp).sort(created_at: 1).last) ? "#{prefix}#{last_filter.name.match(reg_exp)[1].to_i + 1}" : "#{prefix}1"
                 new_filter = Setup::Filter.new(namespace: '',
                                                name: filter_name,
                                                triggers: params[:f].to_json,

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -3,18 +3,18 @@ class Role
   include RailsAdmin::Models::RoleAdmin
 
   has_and_belongs_to_many :users
-  belongs_to :resource, :polymorphic => true
+  belongs_to :resource, polymorphic: true
 
   field :name, type: String
 
   field :metadata
 
   index({
-          :name => 1,
-          :resource_type => 1,
-          :resource_id => 1
+          name: 1,
+          resource_type: 1,
+          resource_id: 1
         },
-        { :unique => true })
+        { unique: true })
 
   scopify
 

--- a/app/models/setup/aws_authorization.rb
+++ b/app/models/setup/aws_authorization.rb
@@ -21,7 +21,7 @@ module Setup
     validates_inclusion_of :signature_method, in: ->(a) { a.signature_method_enum }
     validates_inclusion_of :signature_version, in: ->(a) { a.signature_version_enum }
 
-    auth_headers :'Content-MD5' => ->(auth, template_parameters) { auth.body_do_sign(template_parameters[:body]) }
+    auth_headers 'Content-MD5': ->(auth, template_parameters) { auth.body_do_sign(template_parameters[:body]) }
 
     auth_parameters Timestamp: ->(auth, template_parameters) { auth.timestamp },
                     SignatureMethod: :signature_method,

--- a/app/models/setup/observer.rb
+++ b/app/models/setup/observer.rb
@@ -8,8 +8,8 @@ module Setup
 
     build_in_data_type.referenced_by(:namespace, :name).excluding(:origin)
 
-    belongs_to :data_type, :class_name => Setup::DataType.name, inverse_of: nil
-    belongs_to :trigger_evaluator, :class_name => Setup::Algorithm.name, inverse_of: nil
+    belongs_to :data_type, class_name: Setup::DataType.name, inverse_of: nil
+    belongs_to :trigger_evaluator, class_name: Setup::Algorithm.name, inverse_of: nil
 
     field :triggers, type: String
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,16 +27,16 @@ Cenit::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  config.action_mailer.default_url_options = { :host => ENV['HOST'] }
+  config.action_mailer.default_url_options = { host: ENV['HOST'] }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    :address              => "smtp.gmail.com",
-    :port                 => 587,
-    :domain               => 'cenit.io',
-    :user_name            => ENV['GMAIL_USERNAME'],
-    :password             => ENV['GMAIL_PASSWORD'],
-    :authentication       => 'plain',
-    :enable_starttls_auto => true  }
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: 'cenit.io',
+    user_name: ENV['GMAIL_USERNAME'],
+    password: ENV['GMAIL_PASSWORD'],
+    authentication: 'plain',
+    enable_starttls_auto: true  }
 
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,16 +78,16 @@ Cenit::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  config.action_mailer.default_url_options = { :host => ENV['HOST'] }
+  config.action_mailer.default_url_options = { host: ENV['HOST'] }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    :address              => "smtp.gmail.com",
-    :port                 => 587,
-    :domain               => 'cenitsaas.com',
-    :user_name            => ENV['GMAIL_USERNAME'],
-    :password             => ENV['GMAIL_PASSWORD'],
-    :authentication       => 'plain',
-    :enable_starttls_auto => true  }
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: 'cenitsaas.com',
+    user_name: ENV['GMAIL_USERNAME'],
+    password: ENV['GMAIL_PASSWORD'],
+    authentication: 'plain',
+    enable_starttls_auto: true  }
 
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true

--- a/config/initializers/cancan_monkey_patch.rb
+++ b/config/initializers/cancan_monkey_patch.rb
@@ -12,7 +12,7 @@ module CanCan
 
       def database_records
         if @rules.size.zero?
-          @model_class.where(:_id => {'$exists' => false, '$type' => 7})
+          @model_class.where(_id: {'$exists' => false, '$type' => 7})
         elsif @rules.size == 1 && @rules[0].conditions.is_a?(Mongoid::Criteria)
           @rules[0].conditions
         else

--- a/config/initializers/imgkit.rb
+++ b/config/initializers/imgkit.rb
@@ -4,6 +4,6 @@ IMGKit.configure do |config|
   config.wkhtmltoimage = '/usr/bin/wkhtmltoimage'
   config.default_format = :jpg
   config.default_options = {
-      :quality => 60
+      quality: 60
   }
 end

--- a/config/initializers/nested_form_monkey_patch.rb
+++ b/config/initializers/nested_form_monkey_patch.rb
@@ -28,7 +28,7 @@ module NestedForm
 
       @fields ||= {}
       @template.after_nested_form(fields_blueprint_id) do
-        blueprint = { :id => fields_blueprint_id, :style => 'display: none' }
+        blueprint = { id: fields_blueprint_id, style: 'display: none' }
         block, options = @fields[fields_blueprint_id].values_at(:block, :options)
         options[:child_index] = "new_#{association}"
         blueprint[:"data-blueprint"] = fields_for(association, model_object, options, &block).to_str

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -22,7 +22,7 @@ GC.respond_to?(:copy_on_write_friendly=) and GC.copy_on_write_friendly = true
 working_directory app_dir
 
 # Set up socket location
-listen "#{shared_dir}/sockets/unicorn.#{app_name}.sock", :backlog => 64
+listen "#{shared_dir}/sockets/unicorn.#{app_name}.sock", backlog: 64
 
 # Loging
 stderr_path "#{shared_dir}/log/unicorn.#{app_name}.stderr.log"

--- a/lib/cenit/notebooks.rb
+++ b/lib/cenit/notebooks.rb
@@ -42,9 +42,9 @@ module Cenit
 
     def default_directories
       [
-        {:name => 'REST-API', :parent => ''},
-        {:name => 'SHOWCASE', :parent => ''},
-        {:name => 'COMMUNITY', :parent => ''},
+        {name: 'REST-API', parent: ''},
+        {name: 'SHOWCASE', parent: ''},
+        {name: 'COMMUNITY', parent: ''},
       ]
     end
   end

--- a/lib/cenit/xmlrpc.rb
+++ b/lib/cenit/xmlrpc.rb
@@ -8,8 +8,8 @@ module Cenit
 
     def method_missing(symbol, *args)
       body_request = {
-        :methodCall => {
-          :methodName => symbol
+        methodCall: {
+          methodName: symbol
         }
       }
       body_request[:methodCall][:params] = args.collect { |p| { param: Encoder.hash_encode(p) } } unless args.empty?

--- a/lib/imgkit/imgkit_decorator.rb
+++ b/lib/imgkit/imgkit_decorator.rb
@@ -19,7 +19,7 @@ IMGKit.class_eval do
     if options[:logo]
       content_img = Magick::Image.from_blob(image_converted).first
 
-      logo = Cenit.namespace(options[:namespace]).data_type('images').where(:filename => options[:logo]).first.data
+      logo = Cenit.namespace(options[:namespace]).data_type('images').where(filename: options[:logo]).first.data
       logo = Magick::Image.from_blob(logo) do
         self.format = 'PNG'
         self.background_color = 'White'

--- a/lib/mongoff/metadata_access.rb
+++ b/lib/mongoff/metadata_access.rb
@@ -90,7 +90,7 @@ module Mongoff
         default: String,
         format: {
           date: Date,
-          :'date-time' => DateTime,
+          'date-time': DateTime,
           time: Time
         }
       },

--- a/lib/origami/origami_decorator.rb
+++ b/lib/origami/origami_decorator.rb
@@ -52,20 +52,20 @@ Origami.module_eval do
       page.add_font(:TimesRoman, Origami::Font::Type1::Standard::TimesRoman.new.pre_build)
       write_box = { x: box[:x] + stamp_avatar_options[:width] + 5, y: stamp_avatar_options[:y] + stamp_avatar_options[:height] - 5 }
       contents.write(text, {
-        :x => write_box[:x],
-        :y => write_box[:y],
-        :rendering => Origami::Text::Rendering::FILL,
-        :size => 8,
-        :leading => 8,
-        :font => :TimesRoman,
-        :stroke_color => Origami::ContentStream::DEFAULT_STROKE_COLOR
+        x: write_box[:x],
+        y: write_box[:y],
+        rendering: Origami::Text::Rendering::FILL,
+        size: 8,
+        leading: 8,
+        font: :TimesRoman,
+        stroke_color: Origami::ContentStream::DEFAULT_STROKE_COLOR
       })
 
       # Load stamp sign and add reference to the page
       if options[:annot_stamp][:sign]
         stamp_sign_options = {
-          :x => write_box[:x],
-          :y => stamp_avatar_options[:y],
+          x: write_box[:x],
+          y: stamp_avatar_options[:y],
           width: 50,
           height: 34
         }
@@ -90,10 +90,10 @@ Origami.module_eval do
       # Create the signature annotaion over the content area box
       annotation = Origami::Annotation::Widget::Signature.new
       annotation.Rect = Origami::Rectangle[
-        :llx => box[:x],
-        :lly => box[:y] + box[:height],
-        :urx => box[:x] + box[:width],
-        :ury => box[:y]
+        llx: box[:x],
+        lly: box[:y] + box[:height],
+        urx: box[:x] + box[:width],
+        ury: box[:y]
       ]
 
       # Add the signature annotation to the page
@@ -161,12 +161,12 @@ Origami.module_eval do
 
     # Sign the PDF with the specified keys
     pdf.sign(cert, key,
-      :method => 'adbe.pkcs7.sha1',
-      :annotation => annotation,
-      :location => options[:cert][:location],
-      :contact => options[:annot][:contact],
-      :reason => options[:cert][:reason],
-      :issuer => options[:cert][:issuer],
+      method: 'adbe.pkcs7.sha1',
+      annotation: annotation,
+      location: options[:cert][:location],
+      contact: options[:annot][:contact],
+      reason: options[:cert][:reason],
+      issuer: options[:cert][:issuer],
     )
     [pdf.to_blob, output_filename]
   end

--- a/lib/pdfkit/pdfkit_decorator.rb
+++ b/lib/pdfkit/pdfkit_decorator.rb
@@ -5,11 +5,11 @@ PDFKit.class_eval do
   def self.pdf_from_html(url, options = {})
     header_html = Tempfile.new(%w(header .html))
     if options[:logo]
-      image = Cenit.namespace(options[:namespace]).data_type('images').where(:filename => options[:logo]).first
-      image_temp = Tempfile.new(%w(logo .png), :encoding => 'ascii-8bit')
+      image = Cenit.namespace(options[:namespace]).data_type('images').where(filename: options[:logo]).first
+      image_temp = Tempfile.new(%w(logo .png), encoding: 'ascii-8bit')
       image_temp.write(image.data)
       image_temp.rewind
-      header_html.write(Cenit.namespace(options[:namespace]).translator('header_html').run(:path => image_temp.path))
+      header_html.write(Cenit.namespace(options[:namespace]).translator('header_html').run(path: image_temp.path))
       image_temp.close
     else
       header_html.write(Cenit.namespace(options[:namespace]).snippet('header_html.html.erb').code)
@@ -22,12 +22,12 @@ PDFKit.class_eval do
 
     pdf = new(
         url,
-        :header_html => header_html.path,
-        :footer_html => footer_html.path,
-        :margin_top => options[:margin_top],
-        :margin_bottom => options[:margin_bottom],
-        :margin_left => options[:margin_left],
-        :margin_right => options[:margin_right],
+        header_html: header_html.path,
+        footer_html: footer_html.path,
+        margin_top: options[:margin_top],
+        margin_bottom: options[:margin_bottom],
+        margin_left: options[:margin_left],
+        margin_right: options[:margin_right],
     ).to_pdf
 
     header_html.close

--- a/lib/rails_admin/config/actions/notebooks_root.rb
+++ b/lib/rails_admin/config/actions/notebooks_root.rb
@@ -17,7 +17,7 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-            render :template => 'rails_admin/main/notebooks'
+            render template: 'rails_admin/main/notebooks'
           end
         end
 

--- a/lib/rails_admin/config/actions/rest_api1.rb
+++ b/lib/rails_admin/config/actions/rest_api1.rb
@@ -21,7 +21,7 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-            render :template => 'rails_admin/main/rest_api'
+            render template: 'rails_admin/main/rest_api'
           end
         end
       end

--- a/lib/rails_admin/config/actions/rest_api2.rb
+++ b/lib/rails_admin/config/actions/rest_api2.rb
@@ -21,7 +21,7 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-            render :template => 'rails_admin/main/rest_api'
+            render template: 'rails_admin/main/rest_api'
           end
         end
       end

--- a/lib/rails_admin/config/actions/swagger.rb
+++ b/lib/rails_admin/config/actions/swagger.rb
@@ -28,7 +28,7 @@ module RailsAdmin
                   swagger_set_spec
                 end
               else
-                render :nothing => true, :status => 404
+                render nothing: true, status: 404
               end
             end
           end

--- a/lib/rails_admin/models/setup/converter_admin.rb
+++ b/lib/rails_admin/models/setup/converter_admin.rb
@@ -18,8 +18,8 @@ module RailsAdmin
                 {
                   start:
                     {
-                      :label => I18n.t('admin.config.converter.wizard.start.label'),
-                      :description => I18n.t('admin.config.converter.wizard.start.description')
+                      label: I18n.t('admin.config.converter.wizard.start.label'),
+                      description: I18n.t('admin.config.converter.wizard.start.description')
                     }
                 }
               if bindings[:object].style == 'chain'

--- a/lib/rails_admin/models/setup/filter_admin.rb
+++ b/lib/rails_admin/models/setup/filter_admin.rb
@@ -17,8 +17,8 @@ module RailsAdmin
                 {
                   start:
                     {
-                      :label => I18n.t('admin.config.filter.wizard.start.label'),
-                      :description => I18n.t('admin.config.filter.wizard.start.description')
+                      label: I18n.t('admin.config.filter.wizard.start.label'),
+                      description: I18n.t('admin.config.filter.wizard.start.description')
                     },
                   end:
                     {

--- a/lib/rails_admin/models/setup/flow_admin.rb
+++ b/lib/rails_admin/models/setup/flow_admin.rb
@@ -31,8 +31,8 @@ module RailsAdmin
                 {
                   start:
                     {
-                      :label => I18n.t('admin.config.flow.wizard.start.label'),
-                      :description => I18n.t('admin.config.flow.wizard.start.description')
+                      label: I18n.t('admin.config.flow.wizard.start.label'),
+                      description: I18n.t('admin.config.flow.wizard.start.description')
                     }
                 }
 
@@ -47,15 +47,15 @@ module RailsAdmin
                   # Adjusting steps for custom_data_type field
                   steps[:data_type] =
                     {
-                      :label => "#{I18n.t('admin.config.flow.wizard.source_data_type.label')} #{data_type_label}",
-                      :description => "#{I18n.t('admin.config.flow.wizard.source_data_type.description')} #{data_type_label}"
+                      label: "#{I18n.t('admin.config.flow.wizard.source_data_type.label')} #{data_type_label}",
+                      description: "#{I18n.t('admin.config.flow.wizard.source_data_type.description')} #{data_type_label}"
                     }
                 end
                 if [::Setup::Parser, ::Setup::Renderer].include?(translator.class)
                   steps[:webhook] =
                     {
-                      :label => I18n.t('admin.config.flow.wizard.webhook.label'),
-                      :description => I18n.t('admin.config.flow.wizard.webhook.description')
+                      label: I18n.t('admin.config.flow.wizard.webhook.label'),
+                      description: I18n.t('admin.config.flow.wizard.webhook.description')
                     }
                 end
               end

--- a/lib/rails_admin/models/setup/observer_admin.rb
+++ b/lib/rails_admin/models/setup/observer_admin.rb
@@ -17,8 +17,8 @@ module RailsAdmin
                 {
                   start:
                     {
-                      :label => I18n.t('admin.config.observer.wizard.start.label'),
-                      :description => I18n.t('admin.config.observer.wizard.start.description')
+                      label: I18n.t('admin.config.observer.wizard.start.label'),
+                      description: I18n.t('admin.config.observer.wizard.start.description')
                     },
                   end:
                     {

--- a/lib/rails_admin/models/setup/parser_admin.rb
+++ b/lib/rails_admin/models/setup/parser_admin.rb
@@ -18,8 +18,8 @@ module RailsAdmin
                 {
                   start:
                     {
-                      :label => I18n.t('admin.config.parser.wizard.start.label'),
-                      :description => I18n.t('admin.config.parser.wizard.start.description')
+                      label: I18n.t('admin.config.parser.wizard.start.label'),
+                      description: I18n.t('admin.config.parser.wizard.start.description')
                     },
                   end:
                     {

--- a/lib/rails_admin/models/setup/renderer_admin.rb
+++ b/lib/rails_admin/models/setup/renderer_admin.rb
@@ -18,8 +18,8 @@ module RailsAdmin
                 {
                   start:
                     {
-                      :label => I18n.t('admin.config.renderer.wizard.start.label'),
-                      :description => I18n.t('admin.config.renderer.wizard.start.description')
+                      label: I18n.t('admin.config.renderer.wizard.start.label'),
+                      description: I18n.t('admin.config.renderer.wizard.start.description')
                     },
                   end:
                     {

--- a/lib/rails_admin/models/setup/updater_admin.rb
+++ b/lib/rails_admin/models/setup/updater_admin.rb
@@ -18,8 +18,8 @@ module RailsAdmin
                 {
                   start:
                     {
-                      :label => I18n.t('admin.config.updater.wizard.start.label'),
-                      :description => I18n.t('admin.config.updater.wizard.start.description')
+                      label: I18n.t('admin.config.updater.wizard.start.label'),
+                      description: I18n.t('admin.config.updater.wizard.start.description')
                     },
                   end:
                     {

--- a/lib/rails_admin/rest_api/notebooks.rb
+++ b/lib/rails_admin/rest_api/notebooks.rb
@@ -11,9 +11,9 @@ module RailsAdmin
         nb_name = "api-#{lang[:id]}.ipynb"
 
         Setup::Notebook.where(
-          :name => nb_name,
-          :parent => nb_parent,
-          :type => :notebook
+          name: nb_name,
+          parent: nb_parent,
+          type: :notebook
         ).first || api_create_notebook(lang, nb_parent, nb_name, display_name)
       end
 
@@ -43,10 +43,10 @@ module RailsAdmin
         end
 
         attrs ={
-          :name => nb_name,
-          :parent => nb_parent,
-          :type => :notebook,
-          :content => {
+          name: nb_name,
+          parent: nb_parent,
+          type: :notebook,
+          content: {
             cells: cells,
             metadata: api_notebook_metadata(lang[:id]),
             nbformat: 4,
@@ -61,7 +61,7 @@ module RailsAdmin
       def api_create_notebook_path(nb_parent)
         parent = ""
         nb_parent.split('/').each do |name|
-          directory = Setup::Notebook.where(:name => name, :parent => parent, :type => :directory).first_or_create
+          directory = Setup::Notebook.where(name: name, parent: parent, type: :directory).first_or_create
           directory.origin = :shared
           parent = "#{parent}/#{name}".gsub(/^\//, '')
         end


### PR DESCRIPTION
[Rubocop] Add rule Style/HashSyntax to .rubocop.yml

This cop checks hash literal syntax.

It enforce newer Hash Ruby 1.9 syntax

See for more details: 

https://www.rubydoc.info/gems/rubocop/0.46.0/RuboCop/Cop/Style/HashSyntax

The changes were generated running the next commat

`rubocop --auto-correct --only Style/HashSyntax`

