### PR TITLE
Rubocop rm whitespace

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,6 @@ Style/AlignHash:
 
 Style/HashSyntax:
   Enabled: true
+
+Style/TrailingWhitespace:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ Style/TrailingWhitespace:
 
 Style/EmptyLinesAroundBlockBody:
   Enabled: true
+
+Style/EmptyLinesAroundMethodBody:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,6 @@ Style/HashSyntax:
 
 Style/TrailingWhitespace:
   Enabled: true
+
+Style/EmptyLinesAroundBlockBody:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,6 @@ Style/EmptyLinesAroundBlockBody:
 
 Style/EmptyLinesAroundMethodBody:
   Enabled: true
+
+Style/EmptyLinesAroundModuleBody:
+  Enabled: true

--- a/Capfile
+++ b/Capfile
@@ -1,6 +1,6 @@
 # Load DSL and Setup Up Stages
 require 'capistrano/setup'
- 
+
 # Includes tasks from other gems included in your Gemfile
 #
 # For documentation on these, see for example:
@@ -18,7 +18,7 @@ require 'capistrano/deploy'
 require 'capistrano/unicorn_nginx'
 require 'capistrano/rvm'
 require 'capistrano/bundler'
-require 'capistrano/rails/migrations' 
+require 'capistrano/rails/migrations'
 # require 'capistrano/rbenv'
 # require 'capistrano/chruby'
 # require 'capistrano/rails/assets'

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require File.expand_path('../config/application', __FILE__)
 module TempFixForRakeLastComment
   def last_comment
     last_description
-  end 
+  end
 end
 Rake::Application.send :include, TempFixForRakeLastComment
 Cenit::Application.load_tasks

--- a/app/controllers/api/v3/api_controller.rb
+++ b/app/controllers/api/v3/api_controller.rb
@@ -598,7 +598,6 @@ module Api::V3
 end
 
 module Setup
-
   class DataType
 
     def handle_get_digest(controller)

--- a/app/controllers/rails_admin/application_controller_decorator.rb
+++ b/app/controllers/rails_admin/application_controller_decorator.rb
@@ -1,7 +1,6 @@
 # rails_admin-1.0 ready
 module RailsAdmin
   ApplicationController.class_eval do
-
     attr_reader :context_abstract_model
 
     def to_model_name(param_model_name)

--- a/app/controllers/rails_admin/main_controller_decorator.rb
+++ b/app/controllers/rails_admin/main_controller_decorator.rb
@@ -222,6 +222,5 @@ module RailsAdmin
         redirect_to back_or_index, flash: flash
       end
     end
-
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,3 @@
 module ApplicationHelper
  # TODO Remove this file
-
 end

--- a/app/helpers/rails_admin/application_helper_decorator.rb
+++ b/app/helpers/rails_admin/application_helper_decorator.rb
@@ -1,7 +1,6 @@
 # rails_admin-1.0 ready
 module RailsAdmin
   ApplicationHelper.module_eval do
-
     def format_name(name)
       max_name_length = 30
       if name.length > max_name_length
@@ -640,7 +639,6 @@ module RailsAdmin
             rc.html_safe
           end
         end
-
       end
 
       show_all_link =
@@ -734,7 +732,6 @@ module RailsAdmin
                   </div>
                   </div>'
         end
-
       end
       html.html_safe
     end
@@ -788,7 +785,6 @@ module RailsAdmin
           end
           html += '</ul></li>'
         end
-
       end
       html += '</ul>'
       html.html_safe

--- a/app/helpers/rails_admin/dashboard_helper.rb
+++ b/app/helpers/rails_admin/dashboard_helper.rb
@@ -258,7 +258,6 @@ module RailsAdmin
       menu = menu.concat(tenants)
       menu.join.html_safe
     end
-
   end
 end
 

--- a/app/helpers/rails_admin/form_builder_decorator.rb
+++ b/app/helpers/rails_admin/form_builder_decorator.rb
@@ -1,7 +1,6 @@
 # rails_admin-1.0 ready
 module RailsAdmin
   FormBuilder.class_eval do
-
     alias_method :rails_admin_generate, :generate
 
     def generate(options = {})

--- a/app/helpers/rails_admin/main_helper_decorator.rb
+++ b/app/helpers/rails_admin/main_helper_decorator.rb
@@ -1,7 +1,6 @@
 # rails_admin-1.0 ready
 module RailsAdmin
   MainHelper.class_eval do
-
     alias_method :ra_rails_admin_form_for, :rails_admin_form_for
 
     def rails_admin_form_for(*args, &block)

--- a/app/helpers/rails_admin/notebooks_helper.rb
+++ b/app/helpers/rails_admin/notebooks_helper.rb
@@ -2,7 +2,6 @@ module RailsAdmin
   ###
   # Features to admin and process the notebooks.
   module NotebooksHelper
-
     include RailsAdmin::RestApi::Notebooks
 
     def notebooks_jupyter_url(notebook=nil)
@@ -33,7 +32,6 @@ module RailsAdmin
     def new_setup_notebook
       redirect_to rails_admin.index_path(model_name: 'notebook')
     end
-
   end
 end
 

--- a/app/helpers/rails_admin/override_actions_helper.rb
+++ b/app/helpers/rails_admin/override_actions_helper.rb
@@ -1,6 +1,5 @@
 module RailsAdmin
   module OverrideActionsHelper
-
     def self.included(base)
       RailsAdmin::Config::Actions.all.each do |action|
         base.class_eval <<-EOS, __FILE__, __LINE__ + 1
@@ -22,7 +21,6 @@ module RailsAdmin
         EOS
       end
     end
-
   end
 end
 

--- a/app/helpers/rails_admin/rest_api_helper.rb
+++ b/app/helpers/rails_admin/rest_api_helper.rb
@@ -2,7 +2,6 @@ module RailsAdmin
   ###
   # Generate sdk code for api service.
   module RestApiHelper
-
     include RailsAdmin::RestApi::Curl
     include RailsAdmin::RestApi::Php
     include RailsAdmin::RestApi::Ruby

--- a/app/helpers/rails_admin/swagger_helper.rb
+++ b/app/helpers/rails_admin/swagger_helper.rb
@@ -126,6 +126,5 @@ module RailsAdmin
         render text: 'Success!'
       end
     end
-
   end
 end

--- a/app/helpers/rails_admin/trace_helper.rb
+++ b/app/helpers/rails_admin/trace_helper.rb
@@ -1,6 +1,5 @@
 module RailsAdmin
   module TraceHelper
-
     def show_mongoid_tracer_trace
       respond_to do |format|
         format.json do

--- a/app/helpers/rails_admin/trace_helper.rb
+++ b/app/helpers/rails_admin/trace_helper.rb
@@ -3,7 +3,6 @@ module RailsAdmin
 
     def show_mongoid_tracer_trace
       respond_to do |format|
-
         format.json do
           render json: @object
         end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,7 +8,6 @@ class Ability
   attr_reader :deferred_abilities
 
   def initialize(user)
-
     @deferred_abilities = []
 
     can :access, :rails_admin

--- a/app/models/cenit/app_config.rb
+++ b/app/models/cenit/app_config.rb
@@ -107,7 +107,6 @@ module Cenit
     end
 
     module ClassMethods
-
       def before_validates_configuration(&block)
         block && configuration_callbacks << block
       end

--- a/app/models/cenit/app_config.rb
+++ b/app/models/cenit/app_config.rb
@@ -5,7 +5,6 @@ module Cenit
     BANED_PARAMETER_NAMES = %w(authentication_method logo redirect_uris)
 
     included do
-
       belongs_to :application_id, class_name: ApplicationId.to_s, inverse_of: nil
 
       embeds_many :application_parameters, class_name: Cenit::ApplicationParameter.to_s, inverse_of: :application
@@ -40,7 +39,6 @@ module Cenit
       after_save { application_id.save if application_id.new_record? }
 
       after_destroy { application_id && application_id.destroy }
-
     end
 
     def validates_configuration

--- a/app/models/cenit/oauth_token_common.rb
+++ b/app/models/cenit/oauth_token_common.rb
@@ -5,7 +5,6 @@ module Cenit
     include Cenit::TenantToken
 
     included do
-
       field :user_id
 
       token_length 60

--- a/app/models/concerns/credentials_generator.rb
+++ b/app/models/concerns/credentials_generator.rb
@@ -13,5 +13,4 @@ module CredentialsGenerator
     regenerate_number
     regenerate_token
   end
-
 end

--- a/app/models/concerns/date_time_charts.rb
+++ b/app/models/concerns/date_time_charts.rb
@@ -1,7 +1,6 @@
 module DateTimeCharts
   extend ActiveSupport::Concern
   module ClassMethods
-
     def data_by(set, base_calc, date_field, calculation, acumulate = nil)
       set = set.group_by { |o| acumulate.present? ? o.send(date_field).send(acumulate) : o.send(date_field) }
       met = simple_properties_schemas.key?(base_calc.to_s) ? "map(&:#{base_calc})" : "send(:#{base_calc})" # TODO: Check aggregation calculation when base_calc is a relation

--- a/app/models/concerns/dynamic_validators.rb
+++ b/app/models/concerns/dynamic_validators.rb
@@ -2,7 +2,6 @@ module DynamicValidators
   extend ActiveSupport::Concern
 
   module ClassMethods
-
     def validates_association_length_of(*args)
       args[1][:wrong_length] ||= 'should be of size %{count}'
       args[1][:too_long] ||= 'maximum size %{count} exceeded'

--- a/app/models/concerns/event_lookup.rb
+++ b/app/models/concerns/event_lookup.rb
@@ -8,5 +8,4 @@ module EventLookup
 
     after_save Mongoff::Model.after_save
   end
-
 end

--- a/app/models/concerns/fields_inspection.rb
+++ b/app/models/concerns/fields_inspection.rb
@@ -28,7 +28,6 @@ module FieldsInspection
   end
 
   module ClassMethods
-
     def inspect_fields(*args)
       if args.length.positive?
         @inspecting_fields = args.collect(&:to_s).collect(&:to_sym)

--- a/app/models/concerns/number_generator.rb
+++ b/app/models/concerns/number_generator.rb
@@ -6,7 +6,6 @@ module NumberGenerator
   NUMBER_PREFIX = 'N'
 
   included do
-
     field :number, as: :key, type: String
 
     before_validation :generate_number

--- a/app/models/concerns/number_generator.rb
+++ b/app/models/concerns/number_generator.rb
@@ -38,7 +38,6 @@ module NumberGenerator
   end
 
   module ClassMethods
-
     def by_number(number)
       where(number: number)
     end

--- a/app/models/concerns/observer_tenant_lookup.rb
+++ b/app/models/concerns/observer_tenant_lookup.rb
@@ -4,7 +4,6 @@ module ObserverTenantLookup
   include EventLookup
 
   included do
-
     before_save do
       @_changed_before_save = changed?
       true

--- a/app/models/concerns/thread_aware.rb
+++ b/app/models/concerns/thread_aware.rb
@@ -6,7 +6,6 @@ module ThreadAware
   end
 
   module ClassMethods
-
     def thread_key
       "[cenit]#{to_s}"
     end

--- a/app/models/concerns/time_zone_aware.rb
+++ b/app/models/concerns/time_zone_aware.rb
@@ -2,7 +2,6 @@ module TimeZoneAware
   extend ActiveSupport::Concern
 
   included do
-
     field :time_zone, type: String, default: -> { default_time_zone }
   end
 

--- a/app/models/concerns/time_zone_aware.rb
+++ b/app/models/concerns/time_zone_aware.rb
@@ -32,7 +32,6 @@ module TimeZoneAware
   end
 
   module ClassMethods
-
     def time_zone_enum
       ActiveSupport::TimeZone.all.collect { |e| "#{e.name} | #{e.formatted_offset}" }
     end

--- a/app/models/devise_overrides.rb
+++ b/app/models/devise_overrides.rb
@@ -2,27 +2,27 @@ module DeviseOverrides
   def find_for_authentication(conditions)
     unscoped { super(conditions) }
   end
- 
+
   def serialize_from_session(key, salt)
     unscoped { super(key, salt) }
   end
- 
+
   def send_reset_password_instructions(attributes={})
     unscoped { super(attributes) }
   end
- 
+
   def reset_password_by_token(attributes={})
     unscoped { super(attributes) }
   end
- 
+
   def find_recoverable_or_initialize_with_errors(required_attributes, attributes, error=:invalid)
     unscoped { super(required_attributes, attributes, error) }
   end
- 
+
   def send_confirmation_instructions(attributes={})
     unscoped { super(attributes) }
   end
- 
+
   def confirm_by_token(confirmation_token)
     unscoped { super(confirmation_token) }
   end

--- a/app/models/forms/data_import_common.rb
+++ b/app/models/forms/data_import_common.rb
@@ -5,7 +5,6 @@ module Forms
     include Mongoid::Document
 
     included do
-
       field :file
       field :decompress_content, type: Boolean
       field :data, type: String

--- a/app/models/forms/import_schema.rb
+++ b/app/models/forms/import_schema.rb
@@ -12,7 +12,6 @@ module Forms
       visible false
       register_instance_option(:discard_submit_buttons) { true }
       edit do
-
         field :namespace, :enum_edit do
           enum do
             Setup::Namespace.all.collect(&:name)

--- a/app/models/rails_admin/abstract_model_decorator.rb
+++ b/app/models/rails_admin/abstract_model_decorator.rb
@@ -1,7 +1,6 @@
 # rails_admin-1.0 ready
 module RailsAdmin
   AbstractModel.class_eval do
-
     def model_class
       @model_name.constantize
     end

--- a/app/models/rails_admin/action_not_allowed_decorator.rb
+++ b/app/models/rails_admin/action_not_allowed_decorator.rb
@@ -1,7 +1,6 @@
 # rails_admin-1.0 ready
 module RailsAdmin
   ActionNotAllowed.class_eval do
-
     def initialize(msg = 'Action not allowed')
       super
     end

--- a/app/models/rails_admin/adapters/mongoid/abstract_object_decorator.rb
+++ b/app/models/rails_admin/adapters/mongoid/abstract_object_decorator.rb
@@ -4,7 +4,6 @@ module RailsAdmin
   module Adapters
     module Mongoid
       AbstractObject.class_eval do
-
         def send(*args, &block)
           #Mongoff records always response
           if object.is_a?(Mongoff::Record)

--- a/app/models/rails_admin/adapters/mongoid/statement_builder_decorator.rb
+++ b/app/models/rails_admin/adapters/mongoid/statement_builder_decorator.rb
@@ -5,7 +5,6 @@ module RailsAdmin
   module Adapters
     module Mongoid
       StatementBuilder.class_eval do
-
         def build_statement_for_type
           case @type
           when :boolean

--- a/app/models/rails_admin/adapters/mongoid_decorator.rb
+++ b/app/models/rails_admin/adapters/mongoid_decorator.rb
@@ -4,7 +4,6 @@ require 'rails_admin/adapters/mongoid'
 module RailsAdmin
   module Adapters
     Mongoid.module_eval do
-
       ALIAS_METHODS = proc do
         alias_method_chain :count, :wrapper
       end

--- a/app/models/rails_admin/config/actions/base_decorator.rb
+++ b/app/models/rails_admin/config/actions/base_decorator.rb
@@ -2,7 +2,6 @@ module RailsAdmin
   module Config
     module Actions
       Base.class_eval do
-
         register_instance_option :admin_tail_link? do
           false
         end

--- a/app/models/rails_admin/config/actions/edit_decorator.rb
+++ b/app/models/rails_admin/config/actions/edit_decorator.rb
@@ -2,7 +2,6 @@ module RailsAdmin
   module Config
     module Actions
       Edit.class_eval do
-
         def self.loading_member
           Thread.current[:cenit_pins_off] = true
           yield
@@ -13,7 +12,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             if request.get? # EDIT
 
               if @model_config.asynchronous_persistence
@@ -83,7 +81,6 @@ module RailsAdmin
               end
 
             end
-
           end
         end
       end

--- a/app/models/rails_admin/config/actions/index_decorator.rb
+++ b/app/models/rails_admin/config/actions/index_decorator.rb
@@ -2,7 +2,6 @@ module RailsAdmin
   module Config
     module Actions
       Index.class_eval do
-
         register_instance_option :listing? do
           true
         end

--- a/app/models/rails_admin/config/actions/new_decorator.rb
+++ b/app/models/rails_admin/config/actions/new_decorator.rb
@@ -2,14 +2,12 @@ module RailsAdmin
   module Config
     module Actions
       New.class_eval do
-
         register_instance_option :http_methods do
           [:get, :post, :patch] # NEW / CREATE / COPY
         end
 
         register_instance_option :controller do
           proc do
-
             #Patch
             if request.get? || params[:_restart] # NEW
 

--- a/app/models/rails_admin/config/fields/association_decorator.rb
+++ b/app/models/rails_admin/config/fields/association_decorator.rb
@@ -4,7 +4,6 @@ module RailsAdmin
   module Config
     module Fields
       Association.class_eval do
-
         register_instance_option :nested_form_safe? do
           false
         end

--- a/app/models/rails_admin/config/fields/types/belongs_to_association_decorator.rb
+++ b/app/models/rails_admin/config/fields/types/belongs_to_association_decorator.rb
@@ -3,7 +3,6 @@ module RailsAdmin
     module Fields
       module Types
         BelongsToAssociation.class_eval do
-
           def with(bindings)
             if (obj = bindings[:object]) &&
                obj.new_record? &&

--- a/app/models/rails_admin/config/fields/types/datetime_decorator.rb
+++ b/app/models/rails_admin/config/fields/types/datetime_decorator.rb
@@ -3,7 +3,6 @@ module RailsAdmin
     module Fields
       module Types
         Datetime.class_eval do
-
           register_instance_option :formatted_value do
             if (time = value)
               if (current_account = Account.current)

--- a/app/models/rails_admin/config/fields/types/enum_decorator.rb
+++ b/app/models/rails_admin/config/fields/types/enum_decorator.rb
@@ -3,7 +3,6 @@ module RailsAdmin
     module Fields
       module Types
         Enum.class_eval do
-
           register_instance_option :enum_for_select do
             enum
           end

--- a/app/models/rails_admin/config/fields/types/file_upload_decorator.rb
+++ b/app/models/rails_admin/config/fields/types/file_upload_decorator.rb
@@ -3,7 +3,6 @@ module RailsAdmin
     module Fields
       module Types
         FileUpload.class_eval do
-
           register_instance_option :pretty_value do
             if value.presence
               v = bindings[:view]

--- a/app/models/rails_admin/config/fields/types/text_decorator.rb
+++ b/app/models/rails_admin/config/fields/types/text_decorator.rb
@@ -3,7 +3,6 @@ module RailsAdmin
     module Fields
       module Types
         Text.class_eval do
-
           def parse_input(params)
             case (value = params[name])
             when Hash, Array

--- a/app/models/rails_admin/config/lazy_model_decorator.rb
+++ b/app/models/rails_admin/config/lazy_model_decorator.rb
@@ -1,11 +1,9 @@
 module RailsAdmin
   module Config
     LazyModel.class_eval do
-
       def ready
         @model
       end
-
     end
   end
 end

--- a/app/models/rails_admin/config/model_decorator.rb
+++ b/app/models/rails_admin/config/model_decorator.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     Model.class_eval do
-
       register_instance_option :asynchronous_persistence do
         false
       end

--- a/app/models/rails_admin/config_decorator.rb
+++ b/app/models/rails_admin/config_decorator.rb
@@ -5,7 +5,6 @@ require 'rails_admin/lib/mongoff_abstract_model'
 
 module RailsAdmin
   Config.module_eval do
-
     class << self
 
       def model(entity, &block)
@@ -38,6 +37,5 @@ module RailsAdmin
         @namespace_modules ||= [Setup, Cenit, Forms, Mongoid::Tracer]
       end
     end
-
   end
 end

--- a/app/models/setup/action.rb
+++ b/app/models/setup/action.rb
@@ -81,6 +81,6 @@ module Setup
     def to_s
       "#{method} '#{path}'"
     end
-    
+
   end
 end

--- a/app/models/setup/algorithm_execution.rb
+++ b/app/models/setup/algorithm_execution.rb
@@ -48,6 +48,6 @@ module Setup
         fail "Algorithm with id #{algorithm_id} not found"
       end
     end
-    
+
   end
 end

--- a/app/models/setup/algorithm_validator.rb
+++ b/app/models/setup/algorithm_validator.rb
@@ -27,6 +27,6 @@ module Setup
     rescue Exception => ex
       [ex.message]
     end
-    
+
   end
 end

--- a/app/models/setup/api_pull.rb
+++ b/app/models/setup/api_pull.rb
@@ -26,6 +26,6 @@ module Setup
       fail 'No API to pull' unless api
       super
     end
-    
+
   end
 end

--- a/app/models/setup/api_spec_import.rb
+++ b/app/models/setup/api_spec_import.rb
@@ -28,6 +28,6 @@ module Setup
         end
       end
     end
-    
+
   end
 end

--- a/app/models/setup/attachment_uploader.rb
+++ b/app/models/setup/attachment_uploader.rb
@@ -28,6 +28,5 @@ module Setup
         @attachment_uploader
       end
     end
-
   end
 end

--- a/app/models/setup/attachment_uploader.rb
+++ b/app/models/setup/attachment_uploader.rb
@@ -28,6 +28,6 @@ module Setup
         @attachment_uploader
       end
     end
-    
+
   end
 end

--- a/app/models/setup/authorization_client_common.rb
+++ b/app/models/setup/authorization_client_common.rb
@@ -3,7 +3,6 @@ module Setup
     extend ActiveSupport::Concern
 
     included do
-
       field :identifier, type: String
       field :secret, type: String
 

--- a/app/models/setup/authorization_handler.rb
+++ b/app/models/setup/authorization_handler.rb
@@ -52,6 +52,5 @@ module Setup
         super
       end
     end
-
   end
 end

--- a/app/models/setup/authorization_handler.rb
+++ b/app/models/setup/authorization_handler.rb
@@ -52,6 +52,6 @@ module Setup
         super
       end
     end
-    
+
   end
 end

--- a/app/models/setup/authorization_header.rb
+++ b/app/models/setup/authorization_header.rb
@@ -9,6 +9,5 @@ module Setup
     def build_auth_header(_template_parameters)
       fail NotImplementedError
     end
-
   end
 end

--- a/app/models/setup/authorization_header.rb
+++ b/app/models/setup/authorization_header.rb
@@ -9,6 +9,6 @@ module Setup
     def build_auth_header(_template_parameters)
       fail NotImplementedError
     end
-    
+
   end
 end

--- a/app/models/setup/aws_authorization.rb
+++ b/app/models/setup/aws_authorization.rb
@@ -99,7 +99,7 @@ module Setup
       def normalize_val(value)
         uri_escape(value.respond_to?(:iso8601) ? value.iso8601 : value.to_s)
       end
-      
+
     end
 
   end

--- a/app/models/setup/base_pull.rb
+++ b/app/models/setup/base_pull.rb
@@ -75,6 +75,6 @@ module Setup
     rescue Exception => ex
       raise "Invalid JSON #{uploader.mounted_as}: #{ex.message}"
     end
-    
+
   end
 end

--- a/app/models/setup/basic_authorization.rb
+++ b/app/models/setup/basic_authorization.rb
@@ -27,6 +27,6 @@ module Setup
     def authorized?
       username.present? && password.present?
     end
-    
+
   end
 end

--- a/app/models/setup/bindings.rb
+++ b/app/models/setup/bindings.rb
@@ -18,7 +18,6 @@ module Setup
     end
 
     module ClassMethods
-
       def instantiate(attrs = nil, selected_fields = nil, &block)
         super(attrs, selected_fields) do |doc|
           binds.each do |metadata|
@@ -76,7 +75,6 @@ module Setup
         end
         q
       end
-
     end
   end
 end

--- a/app/models/setup/build_in.rb
+++ b/app/models/setup/build_in.rb
@@ -1,6 +1,5 @@
 module Setup
   module BuildIn
-
     def tracing?
       origin != :cenit
     end

--- a/app/models/setup/bulkable_task.rb
+++ b/app/models/setup/bulkable_task.rb
@@ -28,6 +28,6 @@ module Setup
           fail 'Invalid message: data type ID is missing'
         end
     end
-    
+
   end
 end

--- a/app/models/setup/bulkable_task.rb
+++ b/app/models/setup/bulkable_task.rb
@@ -28,6 +28,5 @@ module Setup
           fail 'Invalid message: data type ID is missing'
         end
     end
-
   end
 end

--- a/app/models/setup/bulkable_transformation.rb
+++ b/app/models/setup/bulkable_transformation.rb
@@ -5,7 +5,6 @@ module Setup
     include WithSourceOptions
 
     included do
-
       field :bulk_source, type: Boolean
 
       before_save do

--- a/app/models/setup/call_link.rb
+++ b/app/models/setup/call_link.rb
@@ -24,6 +24,6 @@ module Setup
       end if link.blank?
       link
     end
-    
+
   end
 end

--- a/app/models/setup/callback_authorization.rb
+++ b/app/models/setup/callback_authorization.rb
@@ -6,7 +6,6 @@ module Setup
     include WithTemplateParameters
 
     included do
-
       field :authorized_at, type: Time
 
       belongs_to :client, class_name: Setup::AuthorizationClient.to_s, inverse_of: nil

--- a/app/models/setup/cenit_scoped.rb
+++ b/app/models/setup/cenit_scoped.rb
@@ -20,7 +20,7 @@ module Setup
       def clean_up
         collection.drop
       end
-      
+
     end
   end
 end

--- a/app/models/setup/cenit_scoped.rb
+++ b/app/models/setup/cenit_scoped.rb
@@ -20,7 +20,6 @@ module Setup
       def clean_up
         collection.drop
       end
-
     end
   end
 end

--- a/app/models/setup/cenit_unscoped.rb
+++ b/app/models/setup/cenit_unscoped.rb
@@ -64,7 +64,6 @@ module Setup
             root
           end
       end
-
     end
   end
 end

--- a/app/models/setup/changed_if.rb
+++ b/app/models/setup/changed_if.rb
@@ -12,14 +12,11 @@ module Setup
     end
 
     module ClassMethods
-
       def changed_if(&block)
         if block
           self.changed_if_blocks << block
         end
       end
-
     end
-
   end
 end

--- a/app/models/setup/changed_if.rb
+++ b/app/models/setup/changed_if.rb
@@ -12,7 +12,7 @@ module Setup
     end
 
     module ClassMethods
-      
+
       def changed_if(&block)
         if block
           self.changed_if_blocks << block

--- a/app/models/setup/class_hierarchy_aware.rb
+++ b/app/models/setup/class_hierarchy_aware.rb
@@ -16,7 +16,6 @@ module ClassHierarchyAware
     end
 
     module ClassMethods
-
       def class_hierarchy
         ([self] + descendants.collect(&:class_hierarchy)).flatten.uniq
       end
@@ -37,8 +36,6 @@ module ClassHierarchyAware
       def concrete?
         !abstract?
       end
-
     end
-
   end
 end

--- a/app/models/setup/class_hierarchy_aware.rb
+++ b/app/models/setup/class_hierarchy_aware.rb
@@ -39,6 +39,6 @@ module ClassHierarchyAware
       end
 
     end
-    
+
   end
 end

--- a/app/models/setup/class_model_parser.rb
+++ b/app/models/setup/class_model_parser.rb
@@ -5,6 +5,6 @@ module Setup
     module ClassMethods
       include InstanceModelParser
     end
-    
+
   end
 end

--- a/app/models/setup/class_model_parser.rb
+++ b/app/models/setup/class_model_parser.rb
@@ -5,6 +5,5 @@ module Setup
     module ClassMethods
       include InstanceModelParser
     end
-
   end
 end

--- a/app/models/setup/collection_behavior.rb
+++ b/app/models/setup/collection_behavior.rb
@@ -275,6 +275,5 @@ module Setup
       end
       true
     end
-
   end
 end

--- a/app/models/setup/collection_data.rb
+++ b/app/models/setup/collection_data.rb
@@ -46,6 +46,6 @@ module Setup
         %w(namespace name records)
       end
     end
-    
+
   end
 end

--- a/app/models/setup/common_parser.rb
+++ b/app/models/setup/common_parser.rb
@@ -1,6 +1,5 @@
 module Setup
   module CommonParser
-
     def regist_creation_listener(listener)
       (@creation_listeners ||= []) << listener
     end
@@ -77,6 +76,5 @@ module Setup
       end
       record
     end
-
   end
 end

--- a/app/models/setup/connection.rb
+++ b/app/models/setup/connection.rb
@@ -74,6 +74,6 @@ module Setup
       end
 
     end
-    
+
   end
 end

--- a/app/models/setup/cross_collection_author.rb
+++ b/app/models/setup/cross_collection_author.rb
@@ -17,6 +17,6 @@ module Setup
     def label
       "#{name} (#{email})"
     end
-    
+
   end
 end

--- a/app/models/setup/cross_origin_shared.rb
+++ b/app/models/setup/cross_origin_shared.rb
@@ -79,7 +79,6 @@ module Setup
     end
 
     module ClassMethods
-
       def shared_deny(*actions)
         Setup::Models.shared_excluded_actions_for self, *actions
       end
@@ -110,8 +109,6 @@ module Setup
         # c + where(origin: :shared).count
         where(:origin.ne => :default).count
       end
-
     end
-
   end
 end

--- a/app/models/setup/crossing.rb
+++ b/app/models/setup/crossing.rb
@@ -49,7 +49,7 @@ module Setup
           [:default, :owner]
         end
       end
-      
+
     end
 
   end

--- a/app/models/setup/custom_title.rb
+++ b/app/models/setup/custom_title.rb
@@ -14,6 +14,5 @@ module Setup
       end
       title
     end
-
   end
 end

--- a/app/models/setup/custom_title.rb
+++ b/app/models/setup/custom_title.rb
@@ -14,6 +14,6 @@ module Setup
       end
       title
     end
-    
+
   end
 end

--- a/app/models/setup/data_import.rb
+++ b/app/models/setup/data_import.rb
@@ -16,6 +16,6 @@ module Setup
                        options: message[:options].deep_dup.with_indifferent_access)
       end
     end
-    
+
   end
 end

--- a/app/models/setup/data_type.rb
+++ b/app/models/setup/data_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Setup
   class DataType
     include SharedConfigurable
@@ -102,7 +103,9 @@ module Setup
     end
 
     def model
-      data_type_name.constantize rescue nil
+      data_type_name.constantize
+    rescue
+      nil
     end
 
     def data_type_name

--- a/app/models/setup/data_type_expansion.rb
+++ b/app/models/setup/data_type_expansion.rb
@@ -49,6 +49,6 @@ module Setup
         end
       end
     end
-    
+
   end
 end

--- a/app/models/setup/data_type_parser.rb
+++ b/app/models/setup/data_type_parser.rb
@@ -28,6 +28,6 @@ module Setup
       Cenit::Utility.bind_references(record, if: EDI_PARSED_RECORD)
       record
     end
-    
+
   end
 end

--- a/app/models/setup/data_type_parser.rb
+++ b/app/models/setup/data_type_parser.rb
@@ -28,6 +28,5 @@ module Setup
       Cenit::Utility.bind_references(record, if: EDI_PARSED_RECORD)
       record
     end
-
   end
 end

--- a/app/models/setup/data_uploader.rb
+++ b/app/models/setup/data_uploader.rb
@@ -11,6 +11,6 @@ module Setup
         store(message.delete(:data), on: data) unless data.present?
       end
     end
-    
+
   end
 end

--- a/app/models/setup/data_uploader.rb
+++ b/app/models/setup/data_uploader.rb
@@ -11,6 +11,5 @@ module Setup
         store(message.delete(:data), on: data) unless data.present?
       end
     end
-
   end
 end

--- a/app/models/setup/edi_validator.rb
+++ b/app/models/setup/edi_validator.rb
@@ -37,6 +37,6 @@ module Setup
     rescue Exception => ex
       [ex.message]
     end
-    
+
   end
 end

--- a/app/models/setup/execution.rb
+++ b/app/models/setup/execution.rb
@@ -77,6 +77,6 @@ module Setup
       end
       content
     end
-    
+
   end
 end

--- a/app/models/setup/filter.rb
+++ b/app/models/setup/filter.rb
@@ -63,5 +63,5 @@ class String
   def to_boolean
     self == 'true'
   end
-  
+
 end

--- a/app/models/setup/format_validator.rb
+++ b/app/models/setup/format_validator.rb
@@ -57,6 +57,6 @@ module Setup
         fail "Can not format to #{format} (schema data type is not configured)"
       end
     end
-    
+
   end
 end

--- a/app/models/setup/format_validator.rb
+++ b/app/models/setup/format_validator.rb
@@ -1,6 +1,5 @@
 module Setup
   module FormatValidator
-
     def data_format
       fail NotImplementedError
     end
@@ -57,6 +56,5 @@ module Setup
         fail "Can not format to #{format} (schema data type is not configured)"
       end
     end
-
   end
 end

--- a/app/models/setup/hash_field.rb
+++ b/app/models/setup/hash_field.rb
@@ -50,7 +50,6 @@ module Setup
     end
 
     module ClassMethods
-
       def local_hash_fields
         @hash_fields ||= []
       end
@@ -72,8 +71,6 @@ module Setup
           local_hash_fields << field_name
         end
       end
-
     end
-
   end
 end

--- a/app/models/setup/instance_model_parser.rb
+++ b/app/models/setup/instance_model_parser.rb
@@ -13,6 +13,6 @@ module Setup
     def new_from_xml(data, options={})
       Edi::Parser.parse_xml(data_type, data, options)
     end
-    
+
   end
 end

--- a/app/models/setup/instance_model_parser.rb
+++ b/app/models/setup/instance_model_parser.rb
@@ -13,6 +13,5 @@ module Setup
     def new_from_xml(data, options={})
       Edi::Parser.parse_xml(data_type, data, options)
     end
-
   end
 end

--- a/app/models/setup/json_metadata.rb
+++ b/app/models/setup/json_metadata.rb
@@ -7,6 +7,5 @@ module Setup
     included do
       hash_field :metadata
     end
-
   end
 end

--- a/app/models/setup/mandatory_namespace.rb
+++ b/app/models/setup/mandatory_namespace.rb
@@ -7,6 +7,6 @@ module Setup
     included do
       validates_presence_of :namespace
     end
-    
+
   end
 end

--- a/app/models/setup/mandatory_namespace.rb
+++ b/app/models/setup/mandatory_namespace.rb
@@ -7,6 +7,5 @@ module Setup
     included do
       validates_presence_of :namespace
     end
-
   end
 end

--- a/app/models/setup/model_configurable.rb
+++ b/app/models/setup/model_configurable.rb
@@ -35,7 +35,6 @@ module Setup
     end
 
     module ClassMethods
-
       attr_reader :config_model, :relation_name, :foreign_key
 
       def inherited(subclass)
@@ -105,7 +104,6 @@ module Setup
         super
         config_model.with(tenant).where(foreign_key.in => ids).delete_all
       end
-
     end
   end
 end

--- a/app/models/setup/models.rb
+++ b/app/models/setup/models.rb
@@ -47,6 +47,6 @@ module Setup
       end
 
     end
-    
+
   end
 end

--- a/app/models/setup/namespace.rb
+++ b/app/models/setup/namespace.rb
@@ -50,6 +50,6 @@ module Setup
     def respond_to?(*args)
       super || Setup::Collection::COLLECTING_PROPERTIES.any? { |name| name.to_s.singularize == args.first.to_s }
     end
-    
+
   end
 end

--- a/app/models/setup/namespace_named.rb
+++ b/app/models/setup/namespace_named.rb
@@ -52,7 +52,6 @@ module Setup
     end
 
     module ClassMethods
-
       def namespace_enum
         (Setup::Namespace.all.collect(&:name) + all.distinct(:namespace).flatten).uniq.sort
       end

--- a/app/models/setup/oauth2_scope.rb
+++ b/app/models/setup/oauth2_scope.rb
@@ -28,6 +28,6 @@ module Setup
     def value
       name
     end
-    
+
   end
 end

--- a/app/models/setup/orm_model_aware.rb
+++ b/app/models/setup/orm_model_aware.rb
@@ -13,6 +13,6 @@ module Setup
         end
       end
     end
-    
+
   end
 end

--- a/app/models/setup/orm_model_aware.rb
+++ b/app/models/setup/orm_model_aware.rb
@@ -13,6 +13,5 @@ module Setup
         end
       end
     end
-
   end
 end

--- a/app/models/setup/parameter.rb
+++ b/app/models/setup/parameter.rb
@@ -3,7 +3,7 @@ module Setup
     include CenitScoped
     include JsonMetadata
     include ChangedIf
-    include RailsAdmin::Models::Setup::ParameterAdmin   
+    include RailsAdmin::Models::Setup::ParameterAdmin
 
     build_in_data_type.with(:key, :value, :description, :metadata).referenced_by(:key)
 

--- a/app/models/setup/parameters.rb
+++ b/app/models/setup/parameters.rb
@@ -23,7 +23,6 @@ module Setup
     end
 
     module ClassMethods
-
       def parameters_relations_names
         @parameters_relations_names || (superclass < Parameters && superclass.parameters_relations_names) || []
       end
@@ -58,8 +57,6 @@ module Setup
           end
         end
       end
-
     end
-
   end
 end

--- a/app/models/setup/parameters.rb
+++ b/app/models/setup/parameters.rb
@@ -60,6 +60,6 @@ module Setup
       end
 
     end
-    
+
   end
 end

--- a/app/models/setup/pull_import.rb
+++ b/app/models/setup/pull_import.rb
@@ -20,6 +20,6 @@ module Setup
       end
       @shared_collection
     end
-    
+
   end
 end

--- a/app/models/setup/pulling_field.rb
+++ b/app/models/setup/pulling_field.rb
@@ -3,7 +3,6 @@ module Setup
     extend ActiveSupport::Concern
 
     module ClassMethods
-
       def pulling(field, options)
         if @pulling_field
           fail "Pulling field already configured: #{@pulling_field}"
@@ -36,8 +35,6 @@ module Setup
         end
         super
       end
-
     end
-
   end
 end

--- a/app/models/setup/pulling_field.rb
+++ b/app/models/setup/pulling_field.rb
@@ -38,6 +38,6 @@ module Setup
       end
 
     end
-    
+
   end
 end

--- a/app/models/setup/push.rb
+++ b/app/models/setup/push.rb
@@ -52,6 +52,6 @@ module Setup
         fail "Collection with id #{source_collection_id} not found"
       end
     end
-    
+
   end
 end

--- a/app/models/setup/req_rej_validator.rb
+++ b/app/models/setup/req_rej_validator.rb
@@ -34,6 +34,5 @@ module Setup
       end
       r
     end
-
   end
 end

--- a/app/models/setup/schema_handler.rb
+++ b/app/models/setup/schema_handler.rb
@@ -1,6 +1,5 @@
 module Setup
   module SchemaHandler
-
     def schema
       fail NotImplementedError
     end
@@ -238,6 +237,5 @@ module Setup
       end if options[:recursive] || (options[:until_merge] && !merged)
       schema
     end
-
   end
 end

--- a/app/models/setup/schema_model_aware.rb
+++ b/app/models/setup/schema_model_aware.rb
@@ -16,6 +16,6 @@ module Setup
       end
 
     end
-    
+
   end
 end

--- a/app/models/setup/schema_model_aware.rb
+++ b/app/models/setup/schema_model_aware.rb
@@ -3,7 +3,6 @@ module Setup
     extend ActiveSupport::Concern
 
     module ClassMethods
-
       def schema_path
         ''
       end
@@ -14,8 +13,6 @@ module Setup
         schema_path.split('/').each { |token| schema = data_type.merge_schema(schema[token]) if token.present? }
         schema
       end
-
     end
-
   end
 end

--- a/app/models/setup/share_with_bindings.rb
+++ b/app/models/setup/share_with_bindings.rb
@@ -11,7 +11,6 @@ module Setup
     end
 
     module ClassMethods
-
       def binding_belongs_to(name, *options)
         r = super
         shared_configurable r.name, r.foreign_key

--- a/app/models/setup/share_with_bindings_and_parameters.rb
+++ b/app/models/setup/share_with_bindings_and_parameters.rb
@@ -6,7 +6,6 @@ module Setup
     include Parameters
 
     module ClassMethods
-
       def clear_config_for(tenant, ids)
         super
         Setup::Parameter.reflect_on_all_associations(:belongs_to).each do |r|
@@ -14,8 +13,6 @@ module Setup
           Setup::Parameter.with(tenant).where(r.foreign_key.to_sym.in => ids).delete_all
         end
       end
-
     end
-
   end
 end

--- a/app/models/setup/shared_collection_pull.rb
+++ b/app/models/setup/shared_collection_pull.rb
@@ -23,6 +23,6 @@ module Setup
     def ask_for_install?
       ::User.current_super_admin? && !shared_collection.installed?
     end
-    
+
   end
 end

--- a/app/models/setup/shared_configurable.rb
+++ b/app/models/setup/shared_configurable.rb
@@ -26,7 +26,6 @@ module Setup
     end
 
     module ClassMethods
-
       def configuring_fields
         @configuring_fields ||= Set.new
       end
@@ -34,8 +33,6 @@ module Setup
       def shared_configurable(*args)
         configuring_fields.merge(args.collect(&:to_s).select(&:present?))
       end
-
     end
-
   end
 end

--- a/app/models/setup/shared_editable.rb
+++ b/app/models/setup/shared_editable.rb
@@ -7,6 +7,6 @@ module Setup
     included do
       shared_allow :edit
     end
-    
+
   end
 end

--- a/app/models/setup/shared_editable.rb
+++ b/app/models/setup/shared_editable.rb
@@ -7,6 +7,5 @@ module Setup
     included do
       shared_allow :edit
     end
-
   end
 end

--- a/app/models/setup/singleton.rb
+++ b/app/models/setup/singleton.rb
@@ -8,7 +8,6 @@ module Setup
     end
 
     module ClassMethods
-
       def singleton_record
         find_or_create_by
       end

--- a/app/models/setup/slug.rb
+++ b/app/models/setup/slug.rb
@@ -61,6 +61,5 @@ module Setup
     def slug_taken?(slug)
       self.class.where(slug: slug, :id.nin => [id]).present?
     end
-
   end
 end

--- a/app/models/setup/slug.rb
+++ b/app/models/setup/slug.rb
@@ -3,7 +3,6 @@ module Setup
     extend ActiveSupport::Concern
 
     included do
-
       field :slug, type: String
 
       validates_length_of :slug, maximum: 255

--- a/app/models/setup/snippet_code.rb
+++ b/app/models/setup/snippet_code.rb
@@ -130,7 +130,6 @@ module Setup
     end
 
     module ClassMethods
-
       def instantiate(attrs = nil, selected_fields = nil)
         record = super
         if record.snippet.nil? && (legacy_code = record.attributes[legacy_code_attribute])

--- a/app/models/setup/snippet_code.rb
+++ b/app/models/setup/snippet_code.rb
@@ -5,7 +5,6 @@ module Setup
     include ShareWithBindings
 
     included do
-
       build_in_data_type.and(
         properties: {
           code: {

--- a/app/models/setup/system_notification_common.rb
+++ b/app/models/setup/system_notification_common.rb
@@ -9,7 +9,6 @@ module Setup
     end
 
     module ClassMethods
-
       def create_from(exception, header = nil)
         header ||= "#{exception.class.to_s.split('::').collect(&:to_title).join('. ')}: #{exception.message}"
         create_with(message: "#{header}: #{exception.message}",
@@ -31,8 +30,6 @@ module Setup
       ensure
         temporary_file.close if temporary_file
       end
-
     end
-
   end
 end

--- a/app/models/setup/system_notification_common.rb
+++ b/app/models/setup/system_notification_common.rb
@@ -33,6 +33,6 @@ module Setup
       end
 
     end
-    
+
   end
 end

--- a/app/models/setup/taggable.rb
+++ b/app/models/setup/taggable.rb
@@ -14,7 +14,7 @@ module Setup
           tags.to_a
         end.flatten.uniq
       end
-      
+
     end
 
   end

--- a/app/models/setup/taggable.rb
+++ b/app/models/setup/taggable.rb
@@ -7,15 +7,12 @@ module Setup
     end
 
     module ClassMethods
-
       def tags_values
         distinct(:tags).flatten.collect do |tags|
           tags = JSON.parse(tags) rescue [tags.to_s]
           tags.to_a
         end.flatten.uniq
       end
-
     end
-
   end
 end

--- a/app/models/setup/target_handler_transformation.rb
+++ b/app/models/setup/target_handler_transformation.rb
@@ -1,6 +1,5 @@
 module Setup
   module TargetHandlerTransformation
-
     def after_execute(options)
       super
       return unless (target = options[:target])

--- a/app/models/setup/template_converter.rb
+++ b/app/models/setup/template_converter.rb
@@ -6,9 +6,7 @@ module Setup
     include SnippetCodeTransformation
 
     included do
-
       validates_presence_of :target_data_type
-
     end
 
     def code_extension

--- a/app/models/setup/translation_common.rb
+++ b/app/models/setup/translation_common.rb
@@ -79,7 +79,7 @@ module Setup
           end
         end
       end
-      
+
     end
   end
 end

--- a/app/models/setup/translation_common.rb
+++ b/app/models/setup/translation_common.rb
@@ -33,7 +33,6 @@ module Setup
     end
 
     module ClassMethods
-
       def parse_options(options)
         options = options.to_s.strip
         options = "{#{options}" unless options.start_with?('{')
@@ -79,7 +78,6 @@ module Setup
           end
         end
       end
-
     end
   end
 end

--- a/app/models/setup/triggers_formatter.rb
+++ b/app/models/setup/triggers_formatter.rb
@@ -18,7 +18,6 @@ module Setup
       end
       modified = nil
       hash.each do |field, conditions|
-
         # LEGACY: Transform form old Hash conditions format to new Array conditions format.
         if conditions.is_a?(Hash)
           hash[field] = conditions = conditions.values
@@ -31,7 +30,6 @@ module Setup
             modified = true
           end
         end
-
       end
       send("#{field}=", hash.to_json) if modified
     end
@@ -40,7 +38,6 @@ module Setup
       r = true
       triggers_hash = JSON.parse(send(field))
       triggers_hash.each do |field_name, conditions|
-
         # LEGACY: Transform form old Hash conditions format to new Array conditions format.
         conditions = conditions.values if conditions.is_a?(Hash)
 
@@ -53,7 +50,6 @@ module Setup
               (obj_before.nil? || !condition_apply(obj_before, obj_now, field_name, condition))
           end
         end
-
       end
       r
     end

--- a/app/models/setup/triggers_formatter.rb
+++ b/app/models/setup/triggers_formatter.rb
@@ -1,6 +1,5 @@
 module Setup
   module TriggersFormatter
-
     def format_triggers_on(field, required = false)
       begin
         send("#{field}=", json = send(field).gsub('=>', ':'))
@@ -194,6 +193,5 @@ module Setup
     def op_last_week(obj_v)
       op_between(obj_v, [nil, (last_week_beginning = Date.today.weeks_ago(1).at_beginning_of_week).at_beginning_of_day, last_week_beginning.at_end_of_week.at_end_of_day])
     end
-
   end
 end

--- a/app/models/setup/uploader_helper.rb
+++ b/app/models/setup/uploader_helper.rb
@@ -41,7 +41,6 @@ module Setup
     end
 
     module ClassMethods
-
       def before_store(&block)
         before_store_callbacks << block
       end
@@ -84,6 +83,5 @@ module Setup
     def readables
       @temp_files ||= []
     end
-
   end
 end

--- a/app/models/setup/uploader_helper.rb
+++ b/app/models/setup/uploader_helper.rb
@@ -3,7 +3,6 @@ module Setup
     extend ActiveSupport::Concern
 
     included do
-
       before_save do
         self.class.before_store_callbacks.each do |callback|
           instance_eval(&callback)

--- a/app/models/setup/uploader_helper.rb
+++ b/app/models/setup/uploader_helper.rb
@@ -85,6 +85,6 @@ module Setup
     def readables
       @temp_files ||= []
     end
-    
+
   end
 end

--- a/app/models/setup/webhook_common.rb
+++ b/app/models/setup/webhook_common.rb
@@ -479,7 +479,6 @@ module Setup
     SYM_METHODS = METHODS.map(&:downcase).map(&:to_sym)
 
     module ClassMethods
-
       def method_enum
         SYM_METHODS
       end

--- a/app/models/setup/with_source_options.rb
+++ b/app/models/setup/with_source_options.rb
@@ -1,6 +1,5 @@
 module Setup
   module WithSourceOptions
-
     def base_execution_options(options)
       opts = super
       opts.merge!(source_options(options))

--- a/app/models/setup/with_template_parameters.rb
+++ b/app/models/setup/with_template_parameters.rb
@@ -1,6 +1,5 @@
 module Setup
   module WithTemplateParameters
-
     def template_parameters_hash
       hash = {}
       template_parameters.each { |p| hash[p.key] = p.value }
@@ -40,6 +39,5 @@ module Setup
       templates.each { |key, template| hash[key] = template && template.render(template_parameters.reverse_merge(template_parameters_hash)) }
       hash
     end
-
   end
 end

--- a/app/models/setup/xslt_template_common.rb
+++ b/app/models/setup/xslt_template_common.rb
@@ -1,6 +1,5 @@
 module Setup
   module XsltTemplateCommon
-
     def output_method(xml_doc = code)
       xml_doc ||= code
       xml_doc = Nokogiri::XML(xml_doc) unless xml_doc.is_a?(Nokogiri::XML::Document)

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,6 @@ module Cenit
     end
 
     config.after_initialize do
-
       Thread.current[:cenit_initializing] = true
 
       puts 'Clearing LOCKS'

--- a/config/initializers/_rolify.rb
+++ b/config/initializers/_rolify.rb
@@ -1,7 +1,7 @@
 Rolify.configure do |config|
   # By default ORM adapter is ActiveRecord. uncomment to use mongoid
   config.use_mongoid
-  
+
   # Dynamic shortcuts for User class (user.is_admin? like methods). Default is: false
   # Enable this feature _after_ running rake db:migrate as it relies on the roles table
   # config.use_dynamic_shortcuts

--- a/config/initializers/cancan_monkey_patch.rb
+++ b/config/initializers/cancan_monkey_patch.rb
@@ -1,7 +1,5 @@
 module CanCan
-
   module Ability
-
     def get_relevant_rules_for_query(action, subject)
       relevant_rules_for_query(action, subject)
     end

--- a/config/initializers/cenit.rb
+++ b/config/initializers/cenit.rb
@@ -3,7 +3,6 @@
 require 'cenit/cenit'
 
 Cenit.config do
-
   share_on_github false
 
   github_shared_collections_home ENV['GITHUB_SHARED_COLLECTIONS_HOME']

--- a/config/initializers/contact_us.rb
+++ b/config/initializers/contact_us.rb
@@ -1,7 +1,6 @@
 require 'cenit/contact_us'
 # Use this hook to configure contact mailer.
 ContactUs.config do |config|
-
   # ==> Mailer Configuration
 
   # Configure the e-mail address which email notifications should be sent from.  If emails must be sent from a verified email address you may set it here.
@@ -31,5 +30,4 @@ ContactUs.config do |config|
   # Configure the parent action mailer
   # Example:
   # config.parent_mailer = "ActionMailer::Base"
-
 end

--- a/config/initializers/cross_origin.rb
+++ b/config/initializers/cross_origin.rb
@@ -9,7 +9,6 @@ module CrossOrigin
     end
 
     module ClassMethods
-
       def cross_origins
         if @origins
           @origins.collect do |origin|

--- a/config/initializers/diffy_monkey_patch.rb
+++ b/config/initializers/diffy_monkey_patch.rb
@@ -86,8 +86,6 @@ module Diffy
           lines.join("\n")
         ]
       end
-
-
     end
 
   end

--- a/config/initializers/mongoff.rb
+++ b/config/initializers/mongoff.rb
@@ -1,7 +1,6 @@
 require 'mongoff/model'
 
 Mongoff::Model.config do
-
   base_schema do
     {
       type: 'object',

--- a/config/initializers/mongoid_monkey_patch.rb
+++ b/config/initializers/mongoid_monkey_patch.rb
@@ -10,15 +10,12 @@ class NilClass
 end
 
 module Mongoid
-
   module Document
-
     def tenant_version
       self
     end
 
     module ClassMethods
-
       def get_associations
         relations
       end
@@ -26,7 +23,6 @@ module Mongoid
   end
 
   module Scopable
-
     private
 
     def apply_default_scoping
@@ -39,7 +35,6 @@ module Mongoid
   end
 
   module Factory
-
     alias_method :mongoid_build, :build
 
     def build(klass, attributes = nil)

--- a/config/initializers/nested_form_monkey_patch.rb
+++ b/config/initializers/nested_form_monkey_patch.rb
@@ -2,7 +2,6 @@ require 'nested_form/builder_mixin.rb'
 
 module NestedForm
   module BuilderMixin
-
     def link_to_add(*args, &block)
       options = args.extract_options!.symbolize_keys
       association = args.pop

--- a/config/initializers/oauth2.rb
+++ b/config/initializers/oauth2.rb
@@ -8,7 +8,6 @@ require 'oauth2/authenticator'
 
 module OAuth2
   Authenticator.class_eval do
-
     alias_method :oauth2_apply, :apply
 
     def apply(params)

--- a/config/initializers/origin_monkey_patch.rb
+++ b/config/initializers/origin_monkey_patch.rb
@@ -5,7 +5,6 @@ module Origin
   module Extensions
     module Symbol
       module ClassMethods
-
         def evolve(object)
           __evolve__(object) { |obj| obj.regexp? ? obj : obj.to_sym }
         end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -257,7 +257,6 @@ module RailsAdmin
 end
 
 RailsAdmin.config do |config|
-
   config.parent_controller = '::ApplicationController'
 
   config.total_columns_width = 900

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -111,9 +111,7 @@ RailsAdmin::Config::Actions.register(:export, RailsAdmin::Config::Actions::BulkE
 require 'rails_admin/config/fields/factories/tag'
 
 module RailsAdmin
-
   module Config
-
     class << self
 
       def navigation(label, options)

--- a/config/initializers/tracer.rb
+++ b/config/initializers/tracer.rb
@@ -1,5 +1,4 @@
 Mongoid::Tracer.configure do |config|
-
   # config.trace_actions :create, :update, :destroy
   #
   # config.trace_ignore :created_at, :updated_at

--- a/config/initializers/zcapataz.rb
+++ b/config/initializers/zcapataz.rb
@@ -1,5 +1,4 @@
 Capataz.config do
-
   disable ENV['CAPATAZ_DISABLE']
 
   maximum_iterations ENV['CAPATAZ_MAXIMUM_ITERATIONS'] || 3000

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Cenit::Application.routes.draw do
-
   devise_for :users, controllers: {
     sessions: 'sessions',
     registrations: 'registrations',

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -47,7 +47,6 @@ before_fork do |server, worker|
 end
 
 after_fork do |server, worker|
-
   defined?(ActiveRecord::Base) and ActiveRecord::Base.establish_connection
   defined?(Rails) and Rails.cache.respond_to?(:reconnect) and Rails.cache.reconnect
 

--- a/lib/cenit/actions.rb
+++ b/lib/cenit/actions.rb
@@ -4,7 +4,6 @@ module Cenit
     class << self
 
       def pull_request(shared_collection, options = {})
-
         pull_parameters = options[:pull_parameters] || {}
         missing_parameters = []
         unless options[:ignore_missing_parameters]

--- a/lib/cenit/cenit.rb
+++ b/lib/cenit/cenit.rb
@@ -1,7 +1,6 @@
 require 'cenit/core_ext'
 
 module Cenit
-
   default_options service_url: '/service',
                   reserved_namespaces: %w(cenit default),
                   rabbit_mq_queue: lambda { Mongoid.default_client.database.name }

--- a/lib/cenit/core_ext.rb
+++ b/lib/cenit/core_ext.rb
@@ -234,7 +234,6 @@ class String
 end
 
 module Enumerable
-
   def to_xml_array(options = {})
     xml_doc = Nokogiri::XML::Document.new
     root = xml_doc.create_element(options[:root] || 'root', type: :array)
@@ -247,7 +246,6 @@ module Enumerable
     xml_doc << root
     xml_doc.to_xml
   end
-
 end
 
 {
@@ -291,7 +289,6 @@ end
 
 module Nokogiri
   module XML
-
     class Builder
 
       def respond_to?(*args)
@@ -361,7 +358,6 @@ end
 
 class V8::Conversion
   module Reference
-
     def self.construct!(object)
       context = V8::Context.current
       constructor = context.to_v8(object.ruby_class)
@@ -386,7 +382,6 @@ require 'zip'
 require 'zip/entry'
 
 module Zip
-
   def decode(zipped_data)
     file = Tempfile.new('zipped_data', encoding: 'ascii-8bit')
     file.write(result = zipped_data)

--- a/lib/cenit/file_store/base.rb
+++ b/lib/cenit/file_store/base.rb
@@ -42,11 +42,9 @@ module Cenit
       end
 
       def set_public_read(file, status)
-
       end
 
       def public_url(file)
-
       end
 
       def stored?(file)

--- a/lib/cenit/file_store/local_db.rb
+++ b/lib/cenit/file_store/local_db.rb
@@ -87,7 +87,6 @@ module Cenit
         n = -1
 
         reading(readable) do |io|
-
           chunking(io, file[:chunkSize]) do |buf|
             md5 << buf
             length += buf.size

--- a/lib/cenit/heroku_client.rb
+++ b/lib/cenit/heroku_client.rb
@@ -1,5 +1,4 @@
 module HerokuClient
-
   class Client
 
     class << self
@@ -126,5 +125,4 @@ module HerokuClient
     end
 
   end
-
 end

--- a/lib/cenit/liquidfier.rb
+++ b/lib/cenit/liquidfier.rb
@@ -1,9 +1,7 @@
 require 'liquid/drop'
 
 module Cenit
-
   module Liquidfier
-
     def to_liquid
       @cenit_liquid_drop ||= Cenit::Liquidfier::Drop.new(self)
     end

--- a/lib/cenit/utility.rb
+++ b/lib/cenit/utility.rb
@@ -80,7 +80,6 @@ module Cenit
         lazy_models = [Setup::MappingConverter]
 
         while_modifying references do
-
           while_modifying references do
             references.each do |obj_waiting, to_bind|
               next if lazy_models.include?(obj_waiting.class)

--- a/lib/edi/filler.rb
+++ b/lib/edi/filler.rb
@@ -1,6 +1,5 @@
 module Edi
   module Filler
-
     def from_edi(data, options={})
       Edi::Parser.parse_edi(self.orm_model.data_type, data, options, self)
       self

--- a/lib/edi/formater.rb
+++ b/lib/edi/formater.rb
@@ -1,6 +1,5 @@
 module Edi
   module Formatter
-
     def self_record
       self
     end

--- a/lib/imgkit/imgkit_decorator.rb
+++ b/lib/imgkit/imgkit_decorator.rb
@@ -3,7 +3,6 @@ require 'rmagick'
 
 IMGKit.class_eval do
   def self.image_from_html(url, options = {})
-
     image = new(url)
     image_converted = ''
 

--- a/lib/json-schema/attributes/mongoff_properties_attribute.rb
+++ b/lib/json-schema/attributes/mongoff_properties_attribute.rb
@@ -7,7 +7,6 @@ module JSON
 
           schema = current_schema.schema
           schema['properties'].each do |property, property_schema|
-
             if property_schema['referenced'] #TODO && mongoff_model_schema?(property_schema)
               if property_schema['type'] == 'array'
                 property = "#{property}_ids"

--- a/lib/json-schema/validators/mongoff.rb
+++ b/lib/json-schema/validators/mongoff.rb
@@ -6,7 +6,6 @@ require 'json-schema/attributes/formats/uint_format'
 require 'json-schema/schema/reader'
 
 module JSON
-
   class Validator
 
     class << self

--- a/lib/liquid/cenit_filters.rb
+++ b/lib/liquid/cenit_filters.rb
@@ -1,6 +1,5 @@
 module Liquid
   module CenitFilters
-
     def hmac_sha256(input, operand)
       input.to_s.hmac_hex_sha256(operand.to_s)
     end

--- a/lib/mongoff/destroyable.rb
+++ b/lib/mongoff/destroyable.rb
@@ -1,6 +1,5 @@
 module Mongoff
   module Destroyable
-
     def destroy(options = {})
       begin
         orm_model.where(id: id).delete_one
@@ -8,6 +7,5 @@ module Mongoff
       end
       @destroyed = true
     end
-
   end
 end

--- a/lib/mongoff/grid_fs/chunk_model.rb
+++ b/lib/mongoff/grid_fs/chunk_model.rb
@@ -1,6 +1,5 @@
 module Mongoff
   module GridFs
-
     class ChunkModel < Model
 
       SCHEMA = Cenit::Utility.stringfy({

--- a/lib/mongoff/grid_fs/file_formatter.rb
+++ b/lib/mongoff/grid_fs/file_formatter.rb
@@ -1,7 +1,6 @@
 module Mongoff
   module GridFs
     module FileFormatter
-
       def to_hash(options = {})
         if (json = native_hash_format(options, :to_hash)).is_a?(String)
           json = JSON.parse(json)

--- a/lib/mongoff/grid_fs/file_model.rb
+++ b/lib/mongoff/grid_fs/file_model.rb
@@ -1,6 +1,5 @@
 module Mongoff
   module GridFs
-
     class FileModel < Mongoff::Model
 
       MINIMUM_CHUNK_SIZE = 2 ** 18

--- a/lib/mongoff/metadata_access.rb
+++ b/lib/mongoff/metadata_access.rb
@@ -1,7 +1,5 @@
 module Mongoff
   module MetadataAccess
-
-
     def property_for(name)
       @properties_by_name ||= {}
       unless @properties_by_name.key?(name)

--- a/lib/mongoff/pretty_errors.rb
+++ b/lib/mongoff/pretty_errors.rb
@@ -1,6 +1,5 @@
 module Mongoff
   module PrettyErrors
-
     def pretty_errors(record)
       return {} unless record
       errors = record.errors.messages.dup.with_indifferent_access

--- a/lib/mongoff/savable.rb
+++ b/lib/mongoff/savable.rb
@@ -1,6 +1,5 @@
 module Mongoff
   module Savable
-
     def save(options = {})
       errors.clear
       if destroyed?
@@ -31,6 +30,5 @@ module Mongoff
       end if orm_model.persistable? && errors.blank?
       errors.blank?
     end
-
   end
 end

--- a/lib/mongoid/cenit_extension.rb
+++ b/lib/mongoid/cenit_extension.rb
@@ -2,13 +2,11 @@ require 'cenit/liquidfier'
 
 module Mongoid
   module Config
-
     def unregist_model(klass)
       LOCK.synchronize do
         models.delete(klass)
       end
     end
-
   end
 
   module CenitDocument
@@ -33,7 +31,6 @@ module Mongoid
     include Cenit::Liquidfier
 
     module ClassMethods
-
       include Mongoff::MetadataAccess
       include Mongoff::PrettyErrors
 

--- a/lib/mongoid/validatable/assertion_validator.rb
+++ b/lib/mongoid/validatable/assertion_validator.rb
@@ -1,6 +1,5 @@
 module Mongoid
   module Validatable
-
     class AssertionValidator < ActiveModel::Validator
 
       def validate(record)
@@ -49,6 +48,5 @@ module Mongoid
       end
 
     end
-
   end
 end

--- a/lib/mongoid/validatable/association_length_validator.rb
+++ b/lib/mongoid/validatable/association_length_validator.rb
@@ -1,6 +1,5 @@
 module Mongoid
   module Validatable
-
     class AssociationLengthValidator < LengthValidator
 
       def validate_each(record, attribute, value)
@@ -9,6 +8,5 @@ module Mongoid
         end
       end
     end
-
   end
 end

--- a/lib/mongoid/validatable/mongoff_validator.rb
+++ b/lib/mongoid/validatable/mongoff_validator.rb
@@ -2,7 +2,6 @@ require 'json-schema/schema/cenit_reader'
 
 module Mongoid
   module Validatable
-
     class MongoffValidator < ActiveModel::EachValidator
 
       def validate_each(record, attribute, value)

--- a/lib/mongoid/validatable/non_blank_format_validator.rb
+++ b/lib/mongoid/validatable/non_blank_format_validator.rb
@@ -1,12 +1,10 @@
 module Mongoid
   module Validatable
-
     class NonBlankFormatValidator < FormatValidator
 
       def validate_each(record, attribute, value)
         super if value.present?
       end
     end
-
   end
 end

--- a/lib/mongoid/validatable/non_blank_inclusion_validator.rb
+++ b/lib/mongoid/validatable/non_blank_inclusion_validator.rb
@@ -1,12 +1,10 @@
 module Mongoid
   module Validatable
-
     class NonBlankInclusionValidator < ActiveModel::Validations::InclusionValidator
 
       def validate_each(record, attribute, value)
         super if value.present?
       end
     end
-
   end
 end

--- a/lib/mongoid/validatable/non_blank_length_validator.rb
+++ b/lib/mongoid/validatable/non_blank_length_validator.rb
@@ -1,12 +1,10 @@
 module Mongoid
   module Validatable
-
     class NonBlankLengthValidator < LengthValidator
 
       def validate_each(record, attribute, value)
         super if value.present?
       end
     end
-
   end
 end

--- a/lib/mongoid/validatable/non_blank_numericality_validator.rb
+++ b/lib/mongoid/validatable/non_blank_numericality_validator.rb
@@ -1,12 +1,10 @@
 module Mongoid
   module Validatable
-
     class NonBlankNumericalityValidator < ActiveModel::Validations::NumericalityValidator
 
       def validate_each(record, attribute, value)
         super if value.present?
       end
     end
-
   end
 end

--- a/lib/mongoid/validatable/non_blank_uniqueness_validator.rb
+++ b/lib/mongoid/validatable/non_blank_uniqueness_validator.rb
@@ -1,12 +1,10 @@
 module Mongoid
   module Validatable
-
     class NonBlankUniquenessValidator < UniquenessValidator
 
       def validate_each(record, attribute, value)
         super if value.present?
       end
     end
-
   end
 end

--- a/lib/origami/origami_decorator.rb
+++ b/lib/origami/origami_decorator.rb
@@ -101,7 +101,6 @@ Origami.module_eval do
 
       [page, annotation]
     end
-
   end
 
   def self.create_cert_and_keys(options={})

--- a/lib/rails_admin/config/actions/algorithm_dependencies.rb
+++ b/lib/rails_admin/config/actions/algorithm_dependencies.rb
@@ -34,7 +34,6 @@ module RailsAdmin
           end
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/authorize.rb
+++ b/lib/rails_admin/config/actions/authorize.rb
@@ -19,7 +19,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             errors = nil
             if @object.check
               if @object.is_a?(Setup::CallbackAuthorization)

--- a/lib/rails_admin/config/actions/authorize.rb
+++ b/lib/rails_admin/config/actions/authorize.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class Authorize < RailsAdmin::Config::Actions::Base
 
         register_instance_option :only do
@@ -54,7 +53,6 @@ module RailsAdmin
           false
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/base_delete_data_type.rb
+++ b/lib/rails_admin/config/actions/base_delete_data_type.rb
@@ -13,7 +13,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             create_selector_token = false
             scope =
               if @object

--- a/lib/rails_admin/config/actions/base_export.rb
+++ b/lib/rails_admin/config/actions/base_export.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class BaseExport < RailsAdmin::Config::Actions::Translate
 
         class << self
@@ -20,7 +19,6 @@ module RailsAdmin
         end
 
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/bulk_export.rb
+++ b/lib/rails_admin/config/actions/bulk_export.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class BulkExport < RailsAdmin::Config::Actions::BaseExport
 
         register_instance_option :collection do
@@ -20,7 +19,6 @@ module RailsAdmin
           :export
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/cancel.rb
+++ b/lib/rails_admin/config/actions/cancel.rb
@@ -17,7 +17,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             if request.get? # Ask
 
               respond_to do |format|

--- a/lib/rails_admin/config/actions/chart.rb
+++ b/lib/rails_admin/config/actions/chart.rb
@@ -25,7 +25,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             model = abstract_model.model rescue nil
             if model && (data_type = model.data_type)
               if data_type.records_model.modelable?
@@ -44,7 +43,6 @@ module RailsAdmin
             else
               redirect_to back_or_index
             end
-
           end
         end
         register_instance_option :i18n_key do

--- a/lib/rails_admin/config/actions/clean_up.rb
+++ b/lib/rails_admin/config/actions/clean_up.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class CleanUp < RailsAdmin::Config::Actions::Base
 
         register_instance_option :only do
@@ -46,7 +45,6 @@ module RailsAdmin
           :trash
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/compare.rb
+++ b/lib/rails_admin/config/actions/compare.rb
@@ -18,7 +18,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             model = @abstract_model.model
             @touched = false
 

--- a/lib/rails_admin/config/actions/compare.rb
+++ b/lib/rails_admin/config/actions/compare.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class Compare < RailsAdmin::Config::Actions::Base
 
         register_instance_option :only do

--- a/lib/rails_admin/config/actions/configure.rb
+++ b/lib/rails_admin/config/actions/configure.rb
@@ -17,7 +17,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             render_form = true
             mongoff_model = @object.configuration_model
             @model_config = RailsAdmin::Config.model(mongoff_model)
@@ -44,7 +43,6 @@ module RailsAdmin
             else
               redirect_to back_or_index
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/convert.rb
+++ b/lib/rails_admin/config/actions/convert.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class Convert < RailsAdmin::Config::Actions::Translate
 
         register_instance_option :collection do

--- a/lib/rails_admin/config/actions/copy.rb
+++ b/lib/rails_admin/config/actions/copy.rb
@@ -13,7 +13,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             model = abstract_model.model rescue nil
             if model
               hash = @object.is_a?(::Mongoff::Record) ? @object.share_hash : @object.copy_hash
@@ -23,7 +22,6 @@ module RailsAdmin
             else
               redirect_to back_or_index
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/data_type.rb
+++ b/lib/rails_admin/config/actions/data_type.rb
@@ -25,14 +25,12 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             model = abstract_model.model rescue nil
             if model && (data_type = model.data_type)
               redirect_to rails_admin.show_path(model_name: data_type.class.to_s.underscore.gsub('/', '~'), id: data_type.id.to_s)
             else
               redirect_to back_or_index
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/data_type_config.rb
+++ b/lib/rails_admin/config/actions/data_type_config.rb
@@ -25,7 +25,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             data_type_config_model = RailsAdmin.config(Setup::DataTypeConfig).abstract_model
 
             if @object.config.new_record?
@@ -36,7 +35,6 @@ module RailsAdmin
             else
               redirect_to rails_admin.show_path(model_name: data_type_config_model.to_param, id: @object.config.id)
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/delete_all.rb
+++ b/lib/rails_admin/config/actions/delete_all.rb
@@ -13,7 +13,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             model = @abstract_model.model rescue nil
             if model
               scope = list_entries(@abstract_model.config, :destroy)

--- a/lib/rails_admin/config/actions/delete_data_type.rb
+++ b/lib/rails_admin/config/actions/delete_data_type.rb
@@ -17,7 +17,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             if params[:delete] # DELETE
               redirect_path = nil
               if @auditing_adapter

--- a/lib/rails_admin/config/actions/disk_usage.rb
+++ b/lib/rails_admin/config/actions/disk_usage.rb
@@ -13,7 +13,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             @max = 0
             @count = {}
             Setup::DataType.all.each do |data_type|
@@ -21,7 +20,6 @@ module RailsAdmin
               @count[data_type.id.to_s] = count = model.is_a?(Class) ? model.storage_size : 0
               @max = count if count > @max
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/documentation.rb
+++ b/lib/rails_admin/config/actions/documentation.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class Documentation < RailsAdmin::Config::Actions::Base
 
         register_instance_option :collection do
@@ -25,7 +24,6 @@ module RailsAdmin
           end
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/download_file.rb
+++ b/lib/rails_admin/config/actions/download_file.rb
@@ -22,7 +22,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             errors = []
             begin
               if @object.class.try(:data_type).is_a?(Setup::FileDataType)
@@ -40,7 +39,6 @@ module RailsAdmin
               do_flash(:error, t('admin.flash.error', name: @model_config.label, action: t("admin.actions.#{@action.key}.done").html_safe), errors)
               redirect_to back_or_index
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/import.rb
+++ b/lib/rails_admin/config/actions/import.rb
@@ -29,7 +29,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             Forms::ImportTranslatorSelector.collection.drop
             selector_config = RailsAdmin::Config.model(Forms::ImportTranslatorSelector)
             render_form = true
@@ -81,7 +80,6 @@ module RailsAdmin
             else
               redirect_to back_or_index
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/import_api_spec.rb
+++ b/lib/rails_admin/config/actions/import_api_spec.rb
@@ -19,7 +19,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             form_config = RailsAdmin::Config.model(Forms::ImportApiSpec)
             if params[:_save] && (message = params[form_config.abstract_model.param_key])
               do_flash_process_result Setup::ApiSpecImport.process(message)
@@ -29,7 +28,6 @@ module RailsAdmin
               @model_config = form_config
               render :form
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/import_schema.rb
+++ b/lib/rails_admin/config/actions/import_schema.rb
@@ -19,7 +19,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             form_config = RailsAdmin::Config.model(Forms::ImportSchema)
             if params[:_save] && (message = params[form_config.abstract_model.param_key])
               do_flash_process_result Setup::SchemasImport.process(message)
@@ -29,7 +28,6 @@ module RailsAdmin
               @model_config = form_config
               render :form
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/inspect.rb
+++ b/lib/rails_admin/config/actions/inspect.rb
@@ -66,7 +66,6 @@ module RailsAdmin
         end
 
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/inspect.rb
+++ b/lib/rails_admin/config/actions/inspect.rb
@@ -22,7 +22,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             if (current_account = Account.current) &&
               (current_user = User.current) &&
               (current_user.super_admin? || current_user.member?(@object))

--- a/lib/rails_admin/config/actions/link_data_type.rb
+++ b/lib/rails_admin/config/actions/link_data_type.rb
@@ -17,7 +17,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             data_type = nil
             Forms::DataTypeSelector.collection.drop
             selector_config = RailsAdmin::Config.model(Forms::DataTypeSelector)

--- a/lib/rails_admin/config/actions/notebooks.rb
+++ b/lib/rails_admin/config/actions/notebooks.rb
@@ -24,7 +24,6 @@ module RailsAdmin
           end
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/notifications.rb
+++ b/lib/rails_admin/config/actions/notifications.rb
@@ -44,7 +44,6 @@ module RailsAdmin
           end
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/open_api_directory.rb
+++ b/lib/rails_admin/config/actions/open_api_directory.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class OpenApiDirectory < RailsAdmin::Config::Actions::Base
 
         register_instance_option :pjax? do
@@ -52,7 +51,6 @@ module RailsAdmin
           'fa fa-cube'
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/process_flow.rb
+++ b/lib/rails_admin/config/actions/process_flow.rb
@@ -25,7 +25,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             if ProcessFlow.processable(@object)
               begin
                 do_flash_process_result(@object.process)

--- a/lib/rails_admin/config/actions/pull.rb
+++ b/lib/rails_admin/config/actions/pull.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class Pull < RailsAdmin::Config::Actions::Base
 
         register_instance_option :pjax? do
@@ -88,7 +87,6 @@ module RailsAdmin
           'icon-arrow-down'
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/pull.rb
+++ b/lib/rails_admin/config/actions/pull.rb
@@ -22,7 +22,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             if (pull_parameters = params[:pull_parameters])
               pull_parameters.permit!
               RailsAdmin::Config.model(@object.pull_model).edit.fields.each { |field| field.parse_input(pull_parameters) }

--- a/lib/rails_admin/config/actions/pull_import.rb
+++ b/lib/rails_admin/config/actions/pull_import.rb
@@ -24,7 +24,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             form_config = RailsAdmin::Config.model(Forms::JsonDataImport)
             view = :form
             model = @abstract_model.model rescue nil
@@ -62,7 +61,6 @@ module RailsAdmin
             else
               redirect_to back_or_index
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/push.rb
+++ b/lib/rails_admin/config/actions/push.rb
@@ -25,7 +25,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             form_config = RailsAdmin::Config.model(Forms::SharedCollectionSelector)
             done = false
             if (data = params[form_config.abstract_model.param_key]) && data.permit! &&

--- a/lib/rails_admin/config/actions/reinstall.rb
+++ b/lib/rails_admin/config/actions/reinstall.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class Reinstall < RailsAdmin::Config::Actions::Base
 
         register_instance_option :only do
@@ -28,7 +27,6 @@ module RailsAdmin
           'icon-repeat'
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/reinstall.rb
+++ b/lib/rails_admin/config/actions/reinstall.rb
@@ -19,10 +19,8 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             @object.reinstall
             redirect_to back_or_index
-
           end
         end
 

--- a/lib/rails_admin/config/actions/remote_shared_collection.rb
+++ b/lib/rails_admin/config/actions/remote_shared_collection.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class RemoteSharedCollection < RailsAdmin::Config::Actions::Base
 
         register_instance_option :visible? do
@@ -111,7 +110,6 @@ module RailsAdmin
           'fa fa-cube'
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/render_chart.rb
+++ b/lib/rails_admin/config/actions/render_chart.rb
@@ -50,7 +50,6 @@ module RailsAdmin
         end
 
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/rest_api1.rb
+++ b/lib/rails_admin/config/actions/rest_api1.rb
@@ -25,7 +25,6 @@ module RailsAdmin
           end
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/rest_api2.rb
+++ b/lib/rails_admin/config/actions/rest_api2.rb
@@ -25,7 +25,6 @@ module RailsAdmin
           end
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/retry_task.rb
+++ b/lib/rails_admin/config/actions/retry_task.rb
@@ -21,7 +21,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             if @object.can_retry?
               @object.retry
             else

--- a/lib/rails_admin/config/actions/run.rb
+++ b/lib/rails_admin/config/actions/run.rb
@@ -17,7 +17,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             mongoff_model = @object.configuration_model
 
             @model_config = RailsAdmin::Config.model(mongoff_model)

--- a/lib/rails_admin/config/actions/run_script.rb
+++ b/lib/rails_admin/config/actions/run_script.rb
@@ -17,7 +17,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             if params[:_run]
               begin
                 if params[:background].present?

--- a/lib/rails_admin/config/actions/schedule.rb
+++ b/lib/rails_admin/config/actions/schedule.rb
@@ -21,7 +21,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             Forms::SchedulerSelector.collection.drop
             if @object.can_schedule?
               done = false
@@ -49,7 +48,6 @@ module RailsAdmin
               flash[:error] = "Can not schedule #{@object}"
               redirect_to back_or_index
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/send_to_flow.rb
+++ b/lib/rails_admin/config/actions/send_to_flow.rb
@@ -25,7 +25,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             Forms::FlowSelector.collection.drop
             model = process_bulk_scope
             selector_config = RailsAdmin::Config.model(Forms::FlowSelector)

--- a/lib/rails_admin/config/actions/share.rb
+++ b/lib/rails_admin/config/actions/share.rb
@@ -18,7 +18,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             shared_collection_config = RailsAdmin::Config.model(Setup::CrossSharedCollection)
             if (shared_params = params.delete(shared_collection_config.abstract_model.param_key))
               sanitize_params_for!(:create, shared_collection_config, shared_params)

--- a/lib/rails_admin/config/actions/share.rb
+++ b/lib/rails_admin/config/actions/share.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class Share < RailsAdmin::Config::Actions::Base
 
         register_instance_option :only do
@@ -55,7 +54,6 @@ module RailsAdmin
           'icon-share'
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/show_records.rb
+++ b/lib/rails_admin/config/actions/show_records.rb
@@ -14,10 +14,8 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             redirect_to rails_admin.index_path(model_name: @object.data_type.records_model.to_s.underscore.gsub('/', '~'),
                                                algorithm_output: @object.id.to_s)
-
           end
         end
 

--- a/lib/rails_admin/config/actions/show_records.rb
+++ b/lib/rails_admin/config/actions/show_records.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class ShowRecords < RailsAdmin::Config::Actions::Base
 
         register_instance_option :only do
@@ -23,7 +22,6 @@ module RailsAdmin
           'icon-list'
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/simple_export.rb
+++ b/lib/rails_admin/config/actions/simple_export.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class SimpleExport < RailsAdmin::Config::Actions::BaseExport
 
         register_instance_option :member do
@@ -13,7 +12,6 @@ module RailsAdmin
         end
 
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/state.rb
+++ b/lib/rails_admin/config/actions/state.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class State < RailsAdmin::Config::Actions::Base
 
         register_instance_option :only do

--- a/lib/rails_admin/config/actions/submit.rb
+++ b/lib/rails_admin/config/actions/submit.rb
@@ -17,7 +17,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             render_form = true
             model = @abstract_model.model rescue nil
             data = {}
@@ -86,7 +85,6 @@ module RailsAdmin
             else
               redirect_to back_or_index
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/sudo.rb
+++ b/lib/rails_admin/config/actions/sudo.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class Sudo < RailsAdmin::Config::Actions::Base
 
         register_instance_option :only do
@@ -44,7 +43,6 @@ module RailsAdmin
         end
 
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/switch_navigation.rb
+++ b/lib/rails_admin/config/actions/switch_navigation.rb
@@ -50,7 +50,6 @@ module RailsAdmin
         end
 
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/switch_scheduler.rb
+++ b/lib/rails_admin/config/actions/switch_scheduler.rb
@@ -40,7 +40,6 @@ module RailsAdmin
         end
 
       end
-
     end
   end
 end

--- a/lib/rails_admin/config/actions/translate.rb
+++ b/lib/rails_admin/config/actions/translate.rb
@@ -22,7 +22,6 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-
             Forms::TransformationSelector.collection.drop
             translation_config = RailsAdmin::Config.model(Forms::TransformationSelector)
             translator_type = @action.class.translator_type
@@ -68,7 +67,6 @@ module RailsAdmin
               @form_object.save(validate: false)
               render :form, locals: { bulk_alert: true }
             end
-
           end
         end
 

--- a/lib/rails_admin/config/actions/translate.rb
+++ b/lib/rails_admin/config/actions/translate.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class Translate < RailsAdmin::Config::Actions::Base
 
         register_instance_option :visible? do

--- a/lib/rails_admin/config/actions/translator_update.rb
+++ b/lib/rails_admin/config/actions/translator_update.rb
@@ -1,7 +1,6 @@
 module RailsAdmin
   module Config
     module Actions
-
       class TranslatorUpdate < RailsAdmin::Config::Actions::Translate
 
         register_instance_option :collection do

--- a/lib/rails_admin/lib/mongoff_attribute_common.rb
+++ b/lib/rails_admin/lib/mongoff_attribute_common.rb
@@ -1,6 +1,5 @@
 module RailsAdmin
   module MongoffAttributeCommon
-
     def hash_schema
       if schema.is_a?(Hash)
         schema

--- a/lib/rails_admin/lib/mongoff_model_config.rb
+++ b/lib/rails_admin/lib/mongoff_model_config.rb
@@ -1,5 +1,4 @@
 module RailsAdmin
-
   class MongoffModelConfig < RailsAdmin::Config::Model
 
     include ThreadAware

--- a/lib/rails_admin/models/account_admin.rb
+++ b/lib/rails_admin/models/account_admin.rb
@@ -68,7 +68,6 @@ module RailsAdmin
           end
 
           fields :_id, :name, :owner, :users, :notification_level, :time_zone
-
         end
       end
 

--- a/lib/rails_admin/models/account_admin.rb
+++ b/lib/rails_admin/models/account_admin.rb
@@ -70,7 +70,6 @@ module RailsAdmin
           fields :_id, :name, :owner, :users, :notification_level, :time_zone
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/models/active_tenant_admin.rb
+++ b/lib/rails_admin/models/active_tenant_admin.rb
@@ -12,7 +12,6 @@ module RailsAdmin
           fields :tenant, :tasks
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/models/cenit/application_id_admin.rb
+++ b/lib/rails_admin/models/cenit/application_id_admin.rb
@@ -53,7 +53,6 @@ module RailsAdmin
             fields :created_at, :name, :registered, :tenant_id, :identifier, :created_at, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/cenit/application_parameter_admin.rb
+++ b/lib/rails_admin/models/cenit/application_parameter_admin.rb
@@ -22,7 +22,6 @@ module RailsAdmin
             fields :name, :type, :many, :group, :description
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/cenit/basic_tenant_token_admin.rb
+++ b/lib/rails_admin/models/cenit/basic_tenant_token_admin.rb
@@ -12,7 +12,6 @@ module RailsAdmin
             visible { ::User.current_super_admin? }
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/cenit/basic_token_admin.rb
+++ b/lib/rails_admin/models/cenit/basic_token_admin.rb
@@ -12,7 +12,6 @@ module RailsAdmin
             visible { ::User.current_super_admin? }
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/cenit/oauth_access_grant_admin.rb
+++ b/lib/rails_admin/models/cenit/oauth_access_grant_admin.rb
@@ -22,7 +22,6 @@ module RailsAdmin
             fields :created_at, :application_id, :scope
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/mongoid/tracer/trace_admin.rb
+++ b/lib/rails_admin/models/mongoid/tracer/trace_admin.rb
@@ -87,7 +87,6 @@ module RailsAdmin
               filter_fields :target_id, :action, :attributes_trace, :created_at
             end
           end
-
         end
       end
     end

--- a/lib/rails_admin/models/rabbit_consumer_admin.rb
+++ b/lib/rails_admin/models/rabbit_consumer_admin.rb
@@ -41,7 +41,6 @@ module RailsAdmin
           fields :created_at, :channel, :tag, :executor, :task_id, :alive, :created_at, :updated_at
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/models/rabbit_consumer_admin.rb
+++ b/lib/rails_admin/models/rabbit_consumer_admin.rb
@@ -39,7 +39,6 @@ module RailsAdmin
           end
 
           fields :created_at, :channel, :tag, :executor, :task_id, :alive, :created_at, :updated_at
-
         end
       end
 

--- a/lib/rails_admin/models/role_admin.rb
+++ b/lib/rails_admin/models/role_admin.rb
@@ -20,7 +20,6 @@ module RailsAdmin
 
           fields :name, :metadata, :users
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/script_execution_admin.rb
+++ b/lib/rails_admin/models/script_execution_admin.rb
@@ -32,7 +32,6 @@ module RailsAdmin
 
           fields :script, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/action_admin.rb
+++ b/lib/rails_admin/models/setup/action_admin.rb
@@ -14,7 +14,6 @@ module RailsAdmin
             fields :method, :path, :algorithm
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/algorithm_admin.rb
+++ b/lib/rails_admin/models/setup/algorithm_admin.rb
@@ -91,7 +91,6 @@ module RailsAdmin
             filter_query_fields :namespace, :name
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/algorithm_execution_admin.rb
+++ b/lib/rails_admin/models/setup/algorithm_execution_admin.rb
@@ -32,7 +32,6 @@ module RailsAdmin
             fields :algorithm, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/algorithm_output_admin.rb
+++ b/lib/rails_admin/models/setup/algorithm_output_admin.rb
@@ -27,7 +27,6 @@ module RailsAdmin
             fields :created_at, :algorithm, :input_parameters, :records_count
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/algorithm_parameter_admin.rb
+++ b/lib/rails_admin/models/setup/algorithm_parameter_admin.rb
@@ -10,7 +10,6 @@ module RailsAdmin
             fields :name, :type, :many, :required, :default
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/algorithm_validator_admin.rb
+++ b/lib/rails_admin/models/setup/algorithm_validator_admin.rb
@@ -22,7 +22,6 @@ module RailsAdmin
             fields :namespace, :name, :algorithm, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/api_pull_admin.rb
+++ b/lib/rails_admin/models/setup/api_pull_admin.rb
@@ -33,7 +33,6 @@ module RailsAdmin
             fields :api, :pull_request, :pulled_request, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/api_spec_admin.rb
+++ b/lib/rails_admin/models/setup/api_spec_admin.rb
@@ -28,7 +28,6 @@ module RailsAdmin
             fields :title, :url, :specification
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/api_spec_import_admin.rb
+++ b/lib/rails_admin/models/setup/api_spec_import_admin.rb
@@ -33,7 +33,6 @@ module RailsAdmin
             fields :base_url, :data, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/app_authorization_admin.rb
+++ b/lib/rails_admin/models/setup/app_authorization_admin.rb
@@ -106,7 +106,6 @@ module RailsAdmin
             fields :namespace, :name, :status, :client, :scopes, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/application_admin.rb
+++ b/lib/rails_admin/models/setup/application_admin.rb
@@ -35,7 +35,6 @@ module RailsAdmin
             fields :namespace, :name, :slug, :identifier, :secret_token, :registered, :actions, :application_parameters
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/asynchronous_persistence_admin.rb
+++ b/lib/rails_admin/models/setup/asynchronous_persistence_admin.rb
@@ -37,7 +37,6 @@ module RailsAdmin
             fields :target_model, :target, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/authorization_admin.rb
+++ b/lib/rails_admin/models/setup/authorization_admin.rb
@@ -37,7 +37,6 @@ module RailsAdmin
             filter_fields :namespace, :name, :authorized, :_type, :metadata, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/authorization_client_admin.rb
+++ b/lib/rails_admin/models/setup/authorization_client_admin.rb
@@ -27,7 +27,6 @@ module RailsAdmin
             fields :provider, :name, :identifier, :secret, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/authorization_provider_admin.rb
+++ b/lib/rails_admin/models/setup/authorization_provider_admin.rb
@@ -30,7 +30,6 @@ module RailsAdmin
             fields :namespace, :name, :_type, :authorization_endpoint
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/aws_authorization_admin.rb
+++ b/lib/rails_admin/models/setup/aws_authorization_admin.rb
@@ -73,7 +73,6 @@ module RailsAdmin
             fields :namespace, :name, :aws_access_key, :aws_secret_key, :seller, :merchant, :markets, :signature_method, :signature_version, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/base_oauth_provider_admin.rb
+++ b/lib/rails_admin/models/setup/base_oauth_provider_admin.rb
@@ -35,7 +35,6 @@ module RailsAdmin
             fields :namespace, :name, :_type, :response_type, :authorization_endpoint, :token_endpoint, :token_method
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/base_pull_admin.rb
+++ b/lib/rails_admin/models/setup/base_pull_admin.rb
@@ -42,7 +42,6 @@ module RailsAdmin
             fields :_type, :pull_request, :pulled_request, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/basic_authorization_admin.rb
+++ b/lib/rails_admin/models/setup/basic_authorization_admin.rb
@@ -55,7 +55,6 @@ module RailsAdmin
             fields :namespace, :name, :status, :username, :password, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/binding_admin.rb
+++ b/lib/rails_admin/models/setup/binding_admin.rb
@@ -67,7 +67,6 @@ module RailsAdmin
             show_in_dashboard false
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/call_link_admin.rb
+++ b/lib/rails_admin/models/setup/call_link_admin.rb
@@ -25,7 +25,6 @@ module RailsAdmin
             fields :name, :link
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/category_admin.rb
+++ b/lib/rails_admin/models/setup/category_admin.rb
@@ -21,7 +21,6 @@ module RailsAdmin
             fields :_id, :title, :description, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/cenit_data_type_admin.rb
+++ b/lib/rails_admin/models/setup/cenit_data_type_admin.rb
@@ -58,7 +58,6 @@ module RailsAdmin
             filter_query_fields :namespace, :name
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/chart_rendering_admin.rb
+++ b/lib/rails_admin/models/setup/chart_rendering_admin.rb
@@ -32,7 +32,6 @@ module RailsAdmin
             fields :description, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/collection_admin.rb
+++ b/lib/rails_admin/models/setup/collection_admin.rb
@@ -18,7 +18,6 @@ module RailsAdmin
             instance_eval &RailsAdmin::Models::Setup::CollectionFieldsConfigAdmin::FIELDS_CONFIG
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/collection_data_admin.rb
+++ b/lib/rails_admin/models/setup/collection_data_admin.rb
@@ -10,7 +10,6 @@ module RailsAdmin
             object_label_method { :label }
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/collection_fields_config_admin.rb
+++ b/lib/rails_admin/models/setup/collection_fields_config_admin.rb
@@ -2,7 +2,6 @@ module RailsAdmin
   module Models
     module Setup
       module CollectionFieldsConfigAdmin
-
         SHARING_INVISIBLE = Proc.new do
           visible { !bindings[:object].instance_variable_get(:@sharing) }
         end

--- a/lib/rails_admin/models/setup/collection_fields_config_admin.rb
+++ b/lib/rails_admin/models/setup/collection_fields_config_admin.rb
@@ -8,7 +8,6 @@ module RailsAdmin
         end
 
         FIELDS_CONFIG = proc do
-
           if abstract_model.model == ::Setup::CrossSharedCollection
             configure :readme, :html_erb
             configure :pull_data, :json_value

--- a/lib/rails_admin/models/setup/configuration_admin.rb
+++ b/lib/rails_admin/models/setup/configuration_admin.rb
@@ -73,7 +73,6 @@ module RailsAdmin
             end
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/connection_admin.rb
+++ b/lib/rails_admin/models/setup/connection_admin.rb
@@ -107,7 +107,6 @@ module RailsAdmin
             fields :namespace, :name, :url, :number, :token, :authorization, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/connection_config_admin.rb
+++ b/lib/rails_admin/models/setup/connection_config_admin.rb
@@ -33,7 +33,6 @@ module RailsAdmin
             show_in_dashboard false
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/connection_role_admin.rb
+++ b/lib/rails_admin/models/setup/connection_role_admin.rb
@@ -55,7 +55,6 @@ module RailsAdmin
             fields :namespace, :name, :webhooks, :connections, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/converter_admin.rb
+++ b/lib/rails_admin/models/setup/converter_admin.rb
@@ -189,7 +189,6 @@ module RailsAdmin
             filter_query_fields :namespace, :name
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/converter_transformation_admin.rb
+++ b/lib/rails_admin/models/setup/converter_transformation_admin.rb
@@ -22,7 +22,6 @@ module RailsAdmin
             fields :namespace, :name, :source_data_type, :target_data_type, :discard_events, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/cross_collection_author_admin.rb
+++ b/lib/rails_admin/models/setup/cross_collection_author_admin.rb
@@ -11,7 +11,6 @@ module RailsAdmin
             fields :name, :email
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/cross_collection_pull_parameter_admin.rb
+++ b/lib/rails_admin/models/setup/cross_collection_pull_parameter_admin.rb
@@ -14,7 +14,6 @@ module RailsAdmin
             fields :label, :type, :many, :required, :description, :properties_locations
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/cross_shared_collection_admin.rb
+++ b/lib/rails_admin/models/setup/cross_shared_collection_admin.rb
@@ -33,7 +33,6 @@ module RailsAdmin
             instance_eval &RailsAdmin::Models::Setup::CollectionFieldsConfigAdmin::FIELDS_CONFIG
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/cross_shared_name_admin.rb
+++ b/lib/rails_admin/models/setup/cross_shared_name_admin.rb
@@ -13,7 +13,6 @@ module RailsAdmin
             fields :name, :owners, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/crossing_admin.rb
+++ b/lib/rails_admin/models/setup/crossing_admin.rb
@@ -31,7 +31,6 @@ module RailsAdmin
             fields :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/custom_validator_admin.rb
+++ b/lib/rails_admin/models/setup/custom_validator_admin.rb
@@ -24,7 +24,6 @@ module RailsAdmin
             fields :namespace, :name, :_type, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/data_import_admin.rb
+++ b/lib/rails_admin/models/setup/data_import_admin.rb
@@ -34,7 +34,6 @@ module RailsAdmin
             fields :translator, :data, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/data_type_admin.rb
+++ b/lib/rails_admin/models/setup/data_type_admin.rb
@@ -107,7 +107,6 @@ module RailsAdmin
             filter_query_fields :namespace, :name
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/data_type_config_admin.rb
+++ b/lib/rails_admin/models/setup/data_type_config_admin.rb
@@ -57,7 +57,6 @@ module RailsAdmin
             show_in_dashboard false
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/data_type_digest_admin.rb
+++ b/lib/rails_admin/models/setup/data_type_digest_admin.rb
@@ -47,7 +47,6 @@ module RailsAdmin
             fields :data_type, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/data_type_expansion_admin.rb
+++ b/lib/rails_admin/models/setup/data_type_expansion_admin.rb
@@ -32,7 +32,6 @@ module RailsAdmin
             fields :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/data_type_generation_admin.rb
+++ b/lib/rails_admin/models/setup/data_type_generation_admin.rb
@@ -32,7 +32,6 @@ module RailsAdmin
             fields :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/delayed_message_admin.rb
+++ b/lib/rails_admin/models/setup/delayed_message_admin.rb
@@ -11,7 +11,6 @@ module RailsAdmin
             visible { ::User.current_super_admin? }
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/deletion_admin.rb
+++ b/lib/rails_admin/models/setup/deletion_admin.rb
@@ -45,7 +45,6 @@ module RailsAdmin
             fields :deletion_model, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/edi_validator_admin.rb
+++ b/lib/rails_admin/models/setup/edi_validator_admin.rb
@@ -25,7 +25,6 @@ module RailsAdmin
             fields :namespace, :name, :schema_data_type, :content_type, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/email_channel_admin.rb
+++ b/lib/rails_admin/models/setup/email_channel_admin.rb
@@ -16,7 +16,6 @@ module RailsAdmin
             fields :namespace, :name, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/email_flow_admin.rb
+++ b/lib/rails_admin/models/setup/email_flow_admin.rb
@@ -15,7 +15,6 @@ module RailsAdmin
             fields :namespace, :name, :send_flow, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/email_notification_admin.rb
+++ b/lib/rails_admin/models/setup/email_notification_admin.rb
@@ -68,7 +68,6 @@ module RailsAdmin
             fields :namespace, :name, :active, :data_type, :observers, :email_channel, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/email_notification_admin.rb
+++ b/lib/rails_admin/models/setup/email_notification_admin.rb
@@ -63,7 +63,6 @@ module RailsAdmin
                 required true
                 visible { !bindings[:object].data_type.nil? }
               end
-
             end
 
             fields :namespace, :name, :active, :data_type, :observers, :email_channel, :updated_at

--- a/lib/rails_admin/models/setup/erb_template_admin.rb
+++ b/lib/rails_admin/models/setup/erb_template_admin.rb
@@ -91,7 +91,6 @@ module RailsAdmin
             fields :namespace, :name, :source_data_type, :mime_type, :file_extension, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/event_admin.rb
+++ b/lib/rails_admin/models/setup/event_admin.rb
@@ -47,7 +47,6 @@ module RailsAdmin
             fields :namespace, :name, :_type, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/execution_admin.rb
+++ b/lib/rails_admin/models/setup/execution_admin.rb
@@ -54,7 +54,6 @@ module RailsAdmin
             fields :created_at, :started_at, :time_span, :status, :attachment, :task, :notifications
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/file_data_type_admin.rb
+++ b/lib/rails_admin/models/setup/file_data_type_admin.rb
@@ -6,7 +6,6 @@ module RailsAdmin
 
         included do
           rails_admin do
-
             navigation_label 'Definitions'
             weight 112
             label 'File Type'

--- a/lib/rails_admin/models/setup/file_data_type_admin.rb
+++ b/lib/rails_admin/models/setup/file_data_type_admin.rb
@@ -128,7 +128,6 @@ module RailsAdmin
             filter_query_fields :namespace, :name
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/file_store_config_admin.rb
+++ b/lib/rails_admin/models/setup/file_store_config_admin.rb
@@ -53,7 +53,6 @@ module RailsAdmin
             show_in_dashboard false
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/file_store_migration_admin.rb
+++ b/lib/rails_admin/models/setup/file_store_migration_admin.rb
@@ -33,7 +33,6 @@ module RailsAdmin
             fields :data_type, :description, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/filter_admin.rb
+++ b/lib/rails_admin/models/setup/filter_admin.rb
@@ -96,7 +96,6 @@ module RailsAdmin
             fields :namespace, :name, :data_type, :segment, :triggers, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/flow_admin.rb
+++ b/lib/rails_admin/models/setup/flow_admin.rb
@@ -359,7 +359,6 @@ module RailsAdmin
             fields :namespace, :name, :description, :active, :event, :translator, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/flow_config_admin.rb
+++ b/lib/rails_admin/models/setup/flow_config_admin.rb
@@ -35,7 +35,6 @@ module RailsAdmin
             show_in_dashboard false
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/flow_execution_admin.rb
+++ b/lib/rails_admin/models/setup/flow_execution_admin.rb
@@ -33,7 +33,6 @@ module RailsAdmin
             fields :flow, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/generic_authorization_client_admin.rb
+++ b/lib/rails_admin/models/setup/generic_authorization_client_admin.rb
@@ -34,7 +34,6 @@ module RailsAdmin
             fields :provider, :name, :identifier, :secret, :tenant, :template_parameters, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/generic_authorization_provider_admin.rb
+++ b/lib/rails_admin/models/setup/generic_authorization_provider_admin.rb
@@ -26,7 +26,6 @@ module RailsAdmin
             fields :namespace, :name, :authorization_endpoint
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/generic_callback_authorization_admin.rb
+++ b/lib/rails_admin/models/setup/generic_callback_authorization_admin.rb
@@ -54,7 +54,6 @@ module RailsAdmin
             fields :namespace, :name, :status, :client, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/handlebars_converter_admin.rb
+++ b/lib/rails_admin/models/setup/handlebars_converter_admin.rb
@@ -75,7 +75,6 @@ module RailsAdmin
             fields :namespace, :name, :source_data_type, :target_data_type, :discard_events, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/handlebars_template_admin.rb
+++ b/lib/rails_admin/models/setup/handlebars_template_admin.rb
@@ -90,7 +90,6 @@ module RailsAdmin
             fields :namespace, :name, :source_data_type, :mime_type, :file_extension, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/json_data_type_admin.rb
+++ b/lib/rails_admin/models/setup/json_data_type_admin.rb
@@ -112,7 +112,6 @@ module RailsAdmin
             filter_query_fields :namespace, :name
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/lazada_authorization_admin.rb
+++ b/lib/rails_admin/models/setup/lazada_authorization_admin.rb
@@ -105,7 +105,6 @@ module RailsAdmin
             fields :namespace, :name, :status, :client, :scopes, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/legacy_translator_admin.rb
+++ b/lib/rails_admin/models/setup/legacy_translator_admin.rb
@@ -182,7 +182,6 @@ module RailsAdmin
             fields :namespace, :name, :type, :style, :code, :source_data_type, :target_data_type, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/liquid_converter_admin.rb
+++ b/lib/rails_admin/models/setup/liquid_converter_admin.rb
@@ -74,7 +74,6 @@ module RailsAdmin
             fields :namespace, :name, :source_data_type, :target_data_type, :discard_events, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/liquid_template_admin.rb
+++ b/lib/rails_admin/models/setup/liquid_template_admin.rb
@@ -86,7 +86,6 @@ module RailsAdmin
             fields :namespace, :name, :source_data_type, :mime_type, :file_extension, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/mapping_converter_admin.rb
+++ b/lib/rails_admin/models/setup/mapping_converter_admin.rb
@@ -106,7 +106,6 @@ module RailsAdmin
             filter_query_fields :namespace, :name
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/namespace_admin.rb
+++ b/lib/rails_admin/models/setup/namespace_admin.rb
@@ -14,7 +14,6 @@ module RailsAdmin
             show_in_dashboard false
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/namespace_collection_admin.rb
+++ b/lib/rails_admin/models/setup/namespace_collection_admin.rb
@@ -39,7 +39,6 @@ module RailsAdmin
             fields :target_collection, :description, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/notebook_admin.rb
+++ b/lib/rails_admin/models/setup/notebook_admin.rb
@@ -13,7 +13,6 @@ module RailsAdmin
             public_access true
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/notification_admin.rb
+++ b/lib/rails_admin/models/setup/notification_admin.rb
@@ -65,7 +65,6 @@ module RailsAdmin
             fields :namespace, :name, :active, :data_type, :observers, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/notification_execution_admin.rb
+++ b/lib/rails_admin/models/setup/notification_execution_admin.rb
@@ -33,7 +33,6 @@ module RailsAdmin
             fields :notification, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/oauth2_authorization_admin.rb
+++ b/lib/rails_admin/models/setup/oauth2_authorization_admin.rb
@@ -107,7 +107,6 @@ module RailsAdmin
             fields :namespace, :name, :status, :client, :scopes, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/oauth2_provider_admin.rb
+++ b/lib/rails_admin/models/setup/oauth2_provider_admin.rb
@@ -46,7 +46,6 @@ module RailsAdmin
             fields :namespace, :name, :response_type, :authorization_endpoint, :token_endpoint, :token_method, :scope_separator, :refresh_token_strategy, :refresh_token_algorithm, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/oauth2_scope_admin.rb
+++ b/lib/rails_admin/models/setup/oauth2_scope_admin.rb
@@ -15,7 +15,6 @@ module RailsAdmin
             fields :provider, :name, :description, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/oauth_authorization_admin.rb
+++ b/lib/rails_admin/models/setup/oauth_authorization_admin.rb
@@ -86,7 +86,6 @@ module RailsAdmin
             fields :namespace, :name, :status, :client, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/oauth_client_admin.rb
+++ b/lib/rails_admin/models/setup/oauth_client_admin.rb
@@ -27,7 +27,6 @@ module RailsAdmin
             fields :provider, :name, :identifier, :secret, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/oauth_provider_admin.rb
+++ b/lib/rails_admin/models/setup/oauth_provider_admin.rb
@@ -36,7 +36,6 @@ module RailsAdmin
             fields :namespace, :name, :response_type, :authorization_endpoint, :token_endpoint, :token_method, :request_token_endpoint,  :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/observer_admin.rb
+++ b/lib/rails_admin/models/setup/observer_admin.rb
@@ -92,7 +92,6 @@ module RailsAdmin
             fields :namespace, :name, :data_type, :triggers, :trigger_evaluator, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/operation_admin.rb
+++ b/lib/rails_admin/models/setup/operation_admin.rb
@@ -35,7 +35,6 @@ module RailsAdmin
             filter_query_fields :none
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/parameter_admin.rb
+++ b/lib/rails_admin/models/setup/parameter_admin.rb
@@ -58,7 +58,6 @@ module RailsAdmin
             fields :parent_model, :parent, :key, :value, :description, :metadata, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/parser_admin.rb
+++ b/lib/rails_admin/models/setup/parser_admin.rb
@@ -108,7 +108,6 @@ module RailsAdmin
             filter_query_fields :namespace, :name
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/parser_transformation_admin.rb
+++ b/lib/rails_admin/models/setup/parser_transformation_admin.rb
@@ -20,7 +20,6 @@ module RailsAdmin
             fields :namespace, :name, :target_data_type, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/pin_admin.rb
+++ b/lib/rails_admin/models/setup/pin_admin.rb
@@ -20,7 +20,6 @@ module RailsAdmin
             show_in_dashboard false
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/plain_webhook_admin.rb
+++ b/lib/rails_admin/models/setup/plain_webhook_admin.rb
@@ -95,7 +95,6 @@ module RailsAdmin
             filter_query_fields :namespace, :name, :path
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/prawn_template_admin.rb
+++ b/lib/rails_admin/models/setup/prawn_template_admin.rb
@@ -56,7 +56,6 @@ module RailsAdmin
             fields :namespace, :name, :source_data_type, :mime_type, :file_extension, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/property_location_admin.rb
+++ b/lib/rails_admin/models/setup/property_location_admin.rb
@@ -12,7 +12,6 @@ module RailsAdmin
             fields :property_name, :location
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/pull_import_admin.rb
+++ b/lib/rails_admin/models/setup/pull_import_admin.rb
@@ -39,7 +39,6 @@ module RailsAdmin
             fields :data, :pull_request, :pulled_request, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/push_admin.rb
+++ b/lib/rails_admin/models/setup/push_admin.rb
@@ -46,7 +46,6 @@ module RailsAdmin
             fields :source_collection, :shared_collection, :description, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/remote_oauth_client_admin.rb
+++ b/lib/rails_admin/models/setup/remote_oauth_client_admin.rb
@@ -34,7 +34,6 @@ module RailsAdmin
             fields :provider, :name, :identifier, :secret, :tenant, :request_token_parameters, :request_token_headers, :template_parameters, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/renderer_admin.rb
+++ b/lib/rails_admin/models/setup/renderer_admin.rb
@@ -129,7 +129,6 @@ module RailsAdmin
             filter_query_fields :namespace, :name
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/resource_admin.rb
+++ b/lib/rails_admin/models/setup/resource_admin.rb
@@ -77,7 +77,6 @@ module RailsAdmin
             filter_query_fields :namespace, :name, :path
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/ruby_converter_admin.rb
+++ b/lib/rails_admin/models/setup/ruby_converter_admin.rb
@@ -73,7 +73,6 @@ module RailsAdmin
             fields :namespace, :name, :source_data_type, :target_data_type, :discard_events, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/ruby_parser_admin.rb
+++ b/lib/rails_admin/models/setup/ruby_parser_admin.rb
@@ -60,7 +60,6 @@ module RailsAdmin
             fields :namespace, :name, :target_data_type, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/ruby_template_admin.rb
+++ b/lib/rails_admin/models/setup/ruby_template_admin.rb
@@ -65,7 +65,6 @@ module RailsAdmin
             fields :namespace, :name, :source_data_type, :mime_type, :file_extension, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/ruby_updater_admin.rb
+++ b/lib/rails_admin/models/setup/ruby_updater_admin.rb
@@ -64,7 +64,6 @@ module RailsAdmin
             fields :namespace, :name, :target_data_type, :discard_events, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/scheduler_admin.rb
+++ b/lib/rails_admin/models/setup/scheduler_admin.rb
@@ -26,7 +26,6 @@ module RailsAdmin
                 html_attributes do
                   { rows: '1' }
                 end
-
               end
             end
 

--- a/lib/rails_admin/models/setup/scheduler_admin.rb
+++ b/lib/rails_admin/models/setup/scheduler_admin.rb
@@ -52,7 +52,6 @@ module RailsAdmin
             fields :namespace, :name, :expression, :activated, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/schema_admin.rb
+++ b/lib/rails_admin/models/setup/schema_admin.rb
@@ -62,7 +62,6 @@ module RailsAdmin
               #field :creator
               field :updated_at
               #field :updater
-
             end
 
             fields :namespace, :uri, :schema_data_type, :updated_at

--- a/lib/rails_admin/models/setup/schema_admin.rb
+++ b/lib/rails_admin/models/setup/schema_admin.rb
@@ -67,7 +67,6 @@ module RailsAdmin
             fields :namespace, :uri, :schema_data_type, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/schemas_import_admin.rb
+++ b/lib/rails_admin/models/setup/schemas_import_admin.rb
@@ -33,7 +33,6 @@ module RailsAdmin
             fields :base_uri, :data, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/shared_collection_pull_admin.rb
+++ b/lib/rails_admin/models/setup/shared_collection_pull_admin.rb
@@ -41,7 +41,6 @@ module RailsAdmin
             fields :shared_collection, :pull_request, :pulled_request, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/smtp_account_admin.rb
+++ b/lib/rails_admin/models/setup/smtp_account_admin.rb
@@ -53,7 +53,6 @@ module RailsAdmin
             fields :provider, :user_name, :authentication, :from
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/smtp_provider_admin.rb
+++ b/lib/rails_admin/models/setup/smtp_provider_admin.rb
@@ -40,7 +40,6 @@ module RailsAdmin
             fields :namespace, :name, :address, :port, :domain, :enable_starttls_auto
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/snippet_admin.rb
+++ b/lib/rails_admin/models/setup/snippet_admin.rb
@@ -54,7 +54,6 @@ module RailsAdmin
             fields :namespace, :name, :type, :description, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/storage_admin.rb
+++ b/lib/rails_admin/models/setup/storage_admin.rb
@@ -58,7 +58,6 @@ module RailsAdmin
             fields :storer_model, :storer_object, :storer_property, :filename, :contentType, :length, :metadata
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/submission_admin.rb
+++ b/lib/rails_admin/models/setup/submission_admin.rb
@@ -34,7 +34,6 @@ module RailsAdmin
             fields :webhook, :connection, :authorization, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/system_notification_admin.rb
+++ b/lib/rails_admin/models/setup/system_notification_admin.rb
@@ -54,7 +54,6 @@ module RailsAdmin
             end
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/system_report_admin.rb
+++ b/lib/rails_admin/models/setup/system_report_admin.rb
@@ -13,7 +13,6 @@ module RailsAdmin
             fields :created_at, :type, :message, :attachment
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/tag_admin.rb
+++ b/lib/rails_admin/models/setup/tag_admin.rb
@@ -11,7 +11,6 @@ module RailsAdmin
             fields :namespace, :name
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/task_admin.rb
+++ b/lib/rails_admin/models/setup/task_admin.rb
@@ -31,7 +31,6 @@ module RailsAdmin
             fields :_type, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/template_admin.rb
+++ b/lib/rails_admin/models/setup/template_admin.rb
@@ -17,7 +17,6 @@ module RailsAdmin
             fields :namespace, :name, :source_data_type, :mime_type, :file_extension, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/translation_admin.rb
+++ b/lib/rails_admin/models/setup/translation_admin.rb
@@ -33,7 +33,6 @@ module RailsAdmin
             fields :translator, :description, :scheduler, :attempts_succeded, :retries, :progress, :status, :executions, :notifications, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/translator_admin.rb
+++ b/lib/rails_admin/models/setup/translator_admin.rb
@@ -16,7 +16,6 @@ module RailsAdmin
             fields :namespace, :name, :type, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/updater_admin.rb
+++ b/lib/rails_admin/models/setup/updater_admin.rb
@@ -112,7 +112,6 @@ module RailsAdmin
 
             filter_query_fields :namespace, :name
           end
-
         end
 
       end

--- a/lib/rails_admin/models/setup/updater_admin.rb
+++ b/lib/rails_admin/models/setup/updater_admin.rb
@@ -113,7 +113,6 @@ module RailsAdmin
             filter_query_fields :namespace, :name
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/updater_transformation_admin.rb
+++ b/lib/rails_admin/models/setup/updater_transformation_admin.rb
@@ -21,7 +21,6 @@ module RailsAdmin
             fields :namespace, :name, :target_data_type, :discard_events, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/validator_admin.rb
+++ b/lib/rails_admin/models/setup/validator_admin.rb
@@ -15,7 +15,6 @@ module RailsAdmin
             show_in_dashboard false
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/web_hook_notification_admin.rb
+++ b/lib/rails_admin/models/setup/web_hook_notification_admin.rb
@@ -79,7 +79,6 @@ module RailsAdmin
             fields :name, :active, :data_type, :observers, :http_method, :url, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/webhook_admin.rb
+++ b/lib/rails_admin/models/setup/webhook_admin.rb
@@ -24,7 +24,6 @@ module RailsAdmin
             fields :namespace, :path, :description, :_type, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/xslt_converter_admin.rb
+++ b/lib/rails_admin/models/setup/xslt_converter_admin.rb
@@ -67,7 +67,6 @@ module RailsAdmin
             fields :namespace, :name, :source_data_type, :target_data_type, :discard_events, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/xslt_template_admin.rb
+++ b/lib/rails_admin/models/setup/xslt_template_admin.rb
@@ -62,7 +62,6 @@ module RailsAdmin
             fields :namespace, :name, :source_data_type, :mime_type, :file_extension, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/setup/xslt_validator_admin.rb
+++ b/lib/rails_admin/models/setup/xslt_validator_admin.rb
@@ -39,7 +39,6 @@ module RailsAdmin
             fields :namespace, :name, :code_warnings, :code, :updated_at
           end
         end
-
       end
     end
   end

--- a/lib/rails_admin/models/task_token_admin.rb
+++ b/lib/rails_admin/models/task_token_admin.rb
@@ -11,7 +11,6 @@ module RailsAdmin
           visible { ::User.current_super_admin? }
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/models/tour_track_admin.rb
+++ b/lib/rails_admin/models/tour_track_admin.rb
@@ -13,7 +13,6 @@ module RailsAdmin
           fields :ip, :user_email, :updated_at
         end
       end
-
     end
   end
 end

--- a/lib/rails_admin/models/user_admin.rb
+++ b/lib/rails_admin/models/user_admin.rb
@@ -191,7 +191,6 @@ module RailsAdmin
             field :sign_in_count
             field :created_at
           end
-
         end
       end
     end

--- a/lib/rails_admin/rest_api/php.rb
+++ b/lib/rails_admin/rest_api/php.rb
@@ -39,7 +39,6 @@ module RailsAdmin
       def api_php_vars(vars)
         vars.map { |k, v| "$#{k} = '#{vars.is_a?(Hash) ? v : "..."}';" }
       end
-
     end
   end
 end

--- a/lib/xsd/attribute_container_tag.rb
+++ b/lib/xsd/attribute_container_tag.rb
@@ -1,6 +1,5 @@
 module Xsd
   module AttributeContainerTag
-
     attr_reader :attributes
 
     def initialize_attribute_container_tag(args)

--- a/lib/xsd/bounded_tag.rb
+++ b/lib/xsd/bounded_tag.rb
@@ -1,6 +1,5 @@
 module Xsd
   module BoundedTag
-
     attr_reader :max_occurs
     attr_reader :min_occurs
 
@@ -20,6 +19,5 @@ module Xsd
           1
         end
     end
-
   end
 end

--- a/lib/xsd/document.rb
+++ b/lib/xsd/document.rb
@@ -1,5 +1,4 @@
 module Xsd
-
   BUILD_IN_TYPES =
     {
       'type:http://www.w3.org/2001/XMLSchema:decimal' => { 'type' => 'number' },

--- a/lib/xsd/referer_tag.rb
+++ b/lib/xsd/referer_tag.rb
@@ -1,11 +1,9 @@
 module Xsd
   module RefererTag
-
     attr_reader :ref
 
     def initialize_referer_tag(args)
       @ref = attributeValue(:ref, args[:attributes])
     end
-
   end
 end

--- a/spec/factories/connection_roles.rb
+++ b/spec/factories/connection_roles.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     connections {[FactoryGirl.create(:store_i_connection)]}
     webhooks {[FactoryGirl.create(:add_product_webhook), FactoryGirl.create(:update_product_webhook) ]}
   end
-  
+
   factory :role_buyer_connection, class: Setup::ConnectionRole do
 
   end

--- a/spec/factories/connection_roles.rb
+++ b/spec/factories/connection_roles.rb
@@ -5,6 +5,5 @@ FactoryGirl.define do
   end
 
   factory :role_buyer_connection, class: Setup::ConnectionRole do
-
   end
 end

--- a/spec/factories/connections.rb
+++ b/spec/factories/connections.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     name 'Store I'
     url 'http://localhost:3001/cenit'
   end
-  
+
   factory :store_ii_connection, class: Setup::Connection do
     name 'Store II'
     url 'http://localhost:3002/cenit'

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,6 +1,4 @@
 FactoryGirl.define do
   factory :role do
-
   end
-
 end

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :role do
-    
+
   end
 
 end

--- a/spec/factories/schemas.rb
+++ b/spec/factories/schemas.rb
@@ -2,13 +2,13 @@ FactoryGirl.define do
   factory :product_schema, class:  Setup::Schema do
     uri 'Product'
 
-    schema do 
+    schema do
       base_path = File.join(Rails.root, 'lib', 'jsons')
       file_schema = Dir.entries(base_path).select { |f| f == 'product.json' }.first
       File.read("#{base_path}/#{file_schema}")
     end
 
-    after(:create) do |schema| 
+    after(:create) do |schema|
       schema.data_types.each do |data_type|
         data_type.create_default_events
       end

--- a/spec/factories/schemas.rb
+++ b/spec/factories/schemas.rb
@@ -13,6 +13,5 @@ FactoryGirl.define do
         data_type.create_default_events
       end
     end
-
   end
 end

--- a/spec/integration/mongoff/record_spec.rb
+++ b/spec/integration/mongoff/record_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Mongoff::Record do
-
   TEST_NAMESPACE = 'Mongoff Test'
 
   B_JSON_SAMPLE = {
@@ -163,7 +162,6 @@ describe Mongoff::Record do
   end
 
   context 'when initialized' do
-
     it 'sets new_record flag to true when initialized' do
       a = new_record_a
       expect(a.new_record?).to eq(true)
@@ -266,7 +264,6 @@ describe Mongoff::Record do
   end
 
   context 'when persisted' do
-
     it 'sets new_record flag to false when persisted' do
       a = new_record_a
       a.save
@@ -303,7 +300,6 @@ describe Mongoff::Record do
   end
 
   context 'when created' do
-
     it 'sets new_record flag to false when created' do
       a = create_record_a
       expect(a.new_record?).to eq(false)
@@ -340,7 +336,6 @@ describe Mongoff::Record do
   end
 
   context 'when loaded' do
-
     it 'sets new_record flag to false when loaded' do
       a = load_record_a
       expect(a.new_record?).to eq(false)

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe Role do
-
   it 'resolve all default roles' do
     roles = Role::FIRST_USER_DEFAULT_NAMES.map { |name| Role.where(name: name).first }
     expect(roles).to all(be)


### PR DESCRIPTION
Add new rules that  checks if are empty lines around the bodies of blocks.

This PR include the next commits:

- [Rubocop] Add Style/TrailingWhitespace to config
  This cop looks for trailing whitespace in the source code.
  https://www.rubydoc.info/gems/rubocop/0.46.0/RuboCop/Cop/Style/TrailingWhitespace

- [Rubocop] Fix rule Style/TrailingWhitespace
 The fixes were generated running the next command
 `rubocop --auto-correct --only Style/TrailingWhitespace`

- [Rubocop] Add rule Style/EmptyLinesAroundBlockBody
  This cops checks if empty lines around the bodies of blocks match the configuration.
  https://www.rubydoc.info/gems/rubocop/0.46.0/RuboCop/Cop/Style/EmptyLinesAroundBlockBody

- [Rubocop] Fix rule Style/EmptyLinesAroundBlockBody
  The fixes were generated running the next command
   `rubocop --auto-correct --only Style/EmptyLinesAroundBlockBody`

- [Rubocop] Add Style/EmptyLinesAroundMethodBody
 This cops checks if empty lines exist around the bodies of methods.
  https://www.rubydoc.info/gems/rubocop/0.46.0/RuboCop/Cop/Style/EmptyLinesAroundMethodBody

- [Rubocop] Fix rule Style/EmptyLinesAroundMethodBody
  The fixes were generated running the next command
   `rubocop --auto-correct --only Style/EmptyLinesAroundMethodBody`

- [Rubocop] Add Style/EmptyLinesAroundModuleBody
  This cops checks if empty lines around the bodies of modules match the configuration.
  https://www.rubydoc.info/gems/rubocop/0.46.0/RuboCop/Cop/Style/EmptyLinesAroundModuleBody

- [Rubocop] Fix rule Style/EmptyLinesAroundModuleBody
  The fixes were generated running the next command
  `rubocop --auto-correct --only Style/EmptyLinesAroundModuleBody`






