### PR TITLE
Upgrade bunny gems to avoid warning with ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'chartkick'
 gem 'descriptive_statistics'
 
 gem 'httparty'
-gem 'bunny'
+gem 'bunny', '~> 2.6'
 gem 'json-schema'
 gem 'nokogiri'
 gem 'cancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    amq-protocol (2.0.0)
+    amq-protocol (2.3.0)
     arel (6.0.4)
     ast (2.3.0)
     autoprefixer-rails (8.5.0)
@@ -136,8 +136,8 @@ GEM
     bson (3.2.6)
     bson_ext (1.5.1)
     builder (3.2.3)
-    bunny (2.2.1)
-      amq-protocol (>= 2.0.0)
+    bunny (2.14.1)
+      amq-protocol (~> 2.3, >= 2.3.0)
     cancan (1.6.10)
     capistrano (3.4.0)
       i18n
@@ -533,7 +533,7 @@ DEPENDENCIES
   bootstrap-wysihtml5-rails (> 0.3.1.24)
   bson_ext
   builder
-  bunny
+  bunny (~> 2.6)
   cancan
   capataz!
   capistrano


### PR DESCRIPTION
Upgrade bunny gem to 2.6.x

`bunny-2.2.1/lib/bunny/channel.rb:1991: warning: constant ::Fixnum is deprecated`