### PR TITLE
Allow redis start with default configuration

### DIFF
--- a/lib/cenit/redis.rb
+++ b/lib/cenit/redis.rb
@@ -10,7 +10,21 @@ module Cenit
 
       def client
         unless instance_variable_defined?(:@redis_client)
-          client = ::Redis.new(host: ENV["REDIS_HOST"], port: 6379, db: 15)
+          client =
+            if (redis_url = ENV['REDIS_URL'])
+              # specify a connection option as a redis:// URL
+              # e.g "redis://:p4ssw0rd@10.0.1.1:6380/15"
+              ::Redis.new(url: redis_url)
+            else
+              # Defauls values similar to the redis gem
+              # https://github.com/redis/redis-rb/blob/master/lib/redis/client.rb#L10-L26
+              redis_host = ENV['REDIS_HOST'] || '127.0.0.1'
+              redis_port = (ENV['REDIS_PORT'] || 6379).to_i
+              redis_db = (ENV['REDIS_DB'] || 0).to_i
+              redis_password = ENV['REDIS_PASSWORD'] || nil
+              
+              ::Redis.new(host: redis_host, port: redis_port, db: redis_db, password: redis_password)
+            end
           client =
             begin
               client.ping


### PR DESCRIPTION
  `redis = Redis.new`

This assumes Redis was started with a default configuration, and is
listening on localhost, port 6379.

Instead allow override with the env variable REDIS_HOST, in that case
is created a new instance with

 `redis = Redis.new(host: ENV["REDIS_HOST"], port 6379, db:15)`