### PR TITLE
Support RAILS_LOG_TO_STDOUT in Unicorn

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -26,8 +26,12 @@ working_directory app_dir
 listen "#{shared_dir}/sockets/unicorn.#{app_name}.sock", backlog: 64
 
 # Loging
-stderr_path "#{shared_dir}/log/unicorn.#{app_name}.stderr.log"
-stdout_path "#{shared_dir}/log/unicorn.#{app_name}.stdout.log"
+if ENV['RAILS_LOG_TO_STDOUT']
+  logger Logger.new(STDOUT)
+else
+  stderr_path "#{shared_dir}/log/unicorn.#{app_name}.stderr.log"
+  stdout_path "#{shared_dir}/log/unicorn.#{app_name}.stdout.log"
+end
 
 # Set master PID location
 pid "#{shared_dir}/pids/unicorn.#{app_name}.pid"


### PR DESCRIPTION
This change is needed to complement https://github.com/cenit-io/cenit/commit/4043bc3f2e7685dd9ffff00f597a8bfab4182aa1 

I've tested this on AWS EKS (managed Kubernetes) and it works perfectly now and I can see the app/unicorn logs.