### PR TITLE
Ability to provide custom auth_source to mongoid

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -89,3 +89,4 @@ production:
        # We recommend 15 because it allows for plenty of time
        # in most operating environments.
        connect_timeout: 15
+       auth_source: <%= ENV.fetch('MONGODB_AUTH_SOURCE', 'admin') %>


### PR DESCRIPTION
This PR enables the setting of `auth_source` in `mongoid.yml`. This is needed by various Mongodb PaaS providers like MongoDB Atlas.

It defaults to `admin` which is the default value as per the mongoid documentation.