### PR TITLE
Fix/Allow configs using env variables

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,6 +51,10 @@ Cenit::Application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  end
+
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,13 +85,14 @@ Cenit::Application.configure do
   config.action_mailer.default_url_options = { host: ENV['HOST'] }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: "smtp.gmail.com",
-    port: 587,
-    domain: 'cenitsaas.com',
-    user_name: ENV['GMAIL_USERNAME'],
-    password: ENV['GMAIL_PASSWORD'],
-    authentication: 'plain',
-    enable_starttls_auto: true  }
+    address: ENV.fetch('SMTP_ADDRESS', 'smtp.gmail.com'),
+    port: ENV.fetch('SMTP_PORT', 587).to_i,
+    domain: ENV.fetch('SMTP_DOMAIN', 'cenitsaas.com'),
+    user_name: ENV.fetch('SMTP_USER_NAME', ENV['GMAIL_USERNAME']),
+    password: ENV.fetch('SMTP_PASSWORD', ENV['GMAIL_PASSWORD']),
+    authentication: ENV.fetch('SMTP_AUTH_TYPE', 'plain'),
+    enable_starttls_auto: ENV.fetch('SMTP_TTLS_AUTO', 'true') == 'true'
+  }
 
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -5,11 +5,11 @@ development:
     default:
       # Defines the name of the default database that Mongoid can connect to.
       # (required).
-      database: <%= ENV['DB_DEV'] || 'cenit_dev' %>
+      database: <%= ENV.fetch('DB_DEV', 'cenit_dev') %>
       # Provides the hosts the default session can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:
-        - <%= ENV['DB_PORT'] || 'localhost:27017' %>
+        - <%= ENV.fetch('DB_PORT', 'localhost:27017') %>
       options:
         # Change whether the session persists in safe mode by default.
         # (default: false)
@@ -65,7 +65,7 @@ development:
 test:
   clients:
     default:
-      database: <%= ENV['DB_TEST'] || 'cenit_test' %>
+      database: <%= ENV.fetch('DB_TEST', 'cenit_test') %>
       hosts:
         - localhost:27017
       options:

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -89,3 +89,4 @@ production:
        # We recommend 15 because it allows for plenty of time
        # in most operating environments.
        connect_timeout: 15
+       auth_source: <%= ENV.fetch('MONGODB_AUTH_SOURCE', 'admin') %>

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -26,8 +26,12 @@ working_directory app_dir
 listen "#{shared_dir}/sockets/unicorn.#{app_name}.sock", backlog: 64
 
 # Loging
-stderr_path "#{shared_dir}/log/unicorn.#{app_name}.stderr.log"
-stdout_path "#{shared_dir}/log/unicorn.#{app_name}.stdout.log"
+if ENV['RAILS_LOG_TO_STDOUT']
+  logger Logger.new(STDOUT)
+else
+  stderr_path "#{shared_dir}/log/unicorn.#{app_name}.stderr.log"
+  stdout_path "#{shared_dir}/log/unicorn.#{app_name}.stdout.log"
+end
 
 # Set master PID location
 pid "#{shared_dir}/pids/unicorn.#{app_name}.pid"

--- a/lib/cenit/rabbit.rb
+++ b/lib/cenit/rabbit.rb
@@ -8,7 +8,7 @@ module Cenit
     class << self
 
       def maximum_active_tasks
-        @maximum__active_tasks ||= (ENV['BASE_MULTIPLIER_ACTIVE_TASKS'] || 50).to_i * (ENV['UNICORN_CENIT_SERVER'].to_b ? Cenit.maximum_unicorn_consumers : 1)
+        @maximum__active_tasks ||= ENV.fetch('BASE_MULTIPLIER_ACTIVE_TASKS', 50).to_i * (ENV['UNICORN_CENIT_SERVER'].to_b ? Cenit.maximum_unicorn_consumers : 1)
       end
 
       def tasks_quota(active_tenants = nil)

--- a/lib/cenit/redis.rb
+++ b/lib/cenit/redis.rb
@@ -19,8 +19,8 @@ module Cenit
               # Defauls values similar to the redis gem
               # https://github.com/redis/redis-rb/blob/master/lib/redis/client.rb#L10-L26
               redis_host = ENV.fetch('REDIS_HOST', '127.0.0.1')
-              redis_port = ENV('REDIS_PORT', 6379).to_i
-              redis_db = ENV('REDIS_DB', 0).to_i
+              redis_port = ENV.fetch('REDIS_PORT', 6379).to_i
+              redis_db = ENV.fetch('REDIS_DB', 0).to_i
               redis_password = ENV['REDIS_PASSWORD']
 
               ::Redis.new(host: redis_host, port: redis_port, db: redis_db, password: redis_password)

--- a/lib/cenit/redis.rb
+++ b/lib/cenit/redis.rb
@@ -18,11 +18,11 @@ module Cenit
             else
               # Defauls values similar to the redis gem
               # https://github.com/redis/redis-rb/blob/master/lib/redis/client.rb#L10-L26
-              redis_host = ENV['REDIS_HOST'] || '127.0.0.1'
-              redis_port = (ENV['REDIS_PORT'] || 6379).to_i
-              redis_db = (ENV['REDIS_DB'] || 0).to_i
-              redis_password = ENV['REDIS_PASSWORD'] || nil
-              
+              redis_host = ENV.fetch('REDIS_HOST', '127.0.0.1')
+              redis_port = ENV('REDIS_PORT', 6379).to_i
+              redis_db = ENV('REDIS_DB', 0).to_i
+              redis_password = ENV['REDIS_PASSWORD']
+
               ::Redis.new(host: redis_host, port: redis_port, db: redis_db, password: redis_password)
             end
           client =


### PR DESCRIPTION
- [x] Control `RAILS_LOG_TO_STDOUT` with ENV variable.
- [x] Control SMTP settings with ENV variables.
- [x] Make mongodb auth_source customizable using ENV variable.
- [x] Use `ENV.fetch` with default values instead of direct `ENV` access with `||`. [why?](https://gist.github.com/stevenharman/5664318)