### PR TITLE
Upgrade mimemagic GEM

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,9 @@ GEM
     method_source (0.9.2)
     mime (0.4.3)
     mime-types (2.99.3)
-    mimemagic (0.3.0)
+    mimemagic (0.4.3)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.9.5)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)


### PR DESCRIPTION
The version of mimemagic 0.3.0 was delete from main provider of GEM. To resolve this bug we did an upgrade of this GEM.