### PR TITLE
Adding validation for unsafe uri ldap

### DIFF
--- a/app/models/setup/webhook_common.rb
+++ b/app/models/setup/webhook_common.rb
@@ -408,6 +408,8 @@ module Setup
         template_parameters['treebase']).presence ||
         ((path = uri.path.presence) && path.split('/').map(&:presence).compact.join(','))
 
+      base =  CGI::unescape(base)
+
       search_options = { base: base }
 
       if (filter = uri.filter)


### PR DESCRIPTION
We have a issue with terms in ldap query base if they have space,  they have to be encoded with %20 to make it a valid uri but it cannot be sent that way for AD server you have to remove this encoding again.