### PR TITLE
Fixed criteria in index an show actions

### DIFF
--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -638,7 +638,7 @@ module Api::V2
         end
         @criteria = @criteria.with_indifferent_access
         @criteria_options = @criteria_options.with_indifferent_access
-        @criteria.merge!(params.reject { |key, _| %w(controller action ns model format api).include?(key) })
+        @criteria.merge!(params.permit!.reject { |key, _| %w(controller action ns model format api).include?(key) })
         @criteria.each { |key, value| @criteria[key] = Cenit::Utility.json_value_of(value) }
         unless (@render_options = Cenit::Utility.json_value_of(request.headers['X-Render-Options'])).is_a?(Hash)
           @render_options = {}


### PR DESCRIPTION
Fixing error when access to /api/v2/...

{
    "request_id": "5b8d304c-ee95-4c61-a5de-eefdaaca8b81",
    "code": "unprocessable_entity",
    "summary": "Action Controller. Unfiltered Parameters: unable to convert unpermitted parameters to hash"
}
