### PR TITLE
Fix how Selector.multi_selection? handles symbols

### DIFF
--- a/lib/mongoff/selector.rb
+++ b/lib/mongoff/selector.rb
@@ -5,5 +5,9 @@ module Mongoff
       value = serializer.evolve_hash(value)
       super
     end
+
+    def multi_selection?(key)
+      %w($and $or $nor).include?(key.to_s)
+    end
   end
 end


### PR DESCRIPTION
Selector.multi_selection? returns incorrectly for the symbol equivalents of "$and" and "$nor" (i.e., :$and and :$nor). This incorrect behavior breaks Selector.merge!(), which is a public Mongoid API exposed to users.

See more details in https://github.com/mongodb/mongoid/pull/4981