### PR TITLE
Fix the double transformation of the parameters when the body of the …

### DIFF
--- a/app/models/concerns/setup/webhook_common.rb
+++ b/app/models/concerns/setup/webhook_common.rb
@@ -71,14 +71,9 @@ module Setup
     end
 
     def submit!(*args, &block)
-      if (options = args[0]).is_a?(Hash)
-        body_argument = options[:body]
-      else
-        body_argument = options
-        options = args[1] || {}
-      end
+      options = args[0].is_a?(Hash) ? args[0] : (args[1] || {}).merge(body: args[0])
       options[:halt_on_error] = true
-      submit(body_argument, options, &block)
+      submit(options, &block)
     end
 
     def notification_model


### PR DESCRIPTION
Fix the double transformation of the parameters when the body of the request is a hash.

This solution does not cover all scenarios that lead to errors in calls to the `submits` methods.

The ideal solution would be to not use the `*args` directive, and instead explicitly define the two necessary body and options parameters and carefully validate all possible cases of their presence or absence.